### PR TITLE
fix instruction synchronization bug on a real RISC-V processor

### DIFF
--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -60,6 +60,9 @@ exec(char *path, char **argv)
   end_op();
   ip = 0;
 
+  // Synchronize the instruction and data streams.
+  asm volatile("fence.i");
+
   p = myproc();
   uint64 oldsz = p->sz;
 

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -334,6 +334,10 @@ uvmcopy(pagetable_t old, pagetable_t new, uint64 sz)
       goto err;
     }
   }
+
+  // Synchronize the instruction and data streams,
+  // since we may copy pages with instructions.
+  asm volatile("fence.i");
   return 0;
 
  err:


### PR DESCRIPTION
* RISC-V does not guarantee that a stored instruction can be seen by the
  subsequent instruction fetches. This is a case of loading user
  programs in an operating system. The original kernel can run on QEMU.
  But to run on a real RISC-V processor, we should use FENCE.I to let
  subsequent instruction fetches see the stored instructions.

* Fork() will also copy pages containing instructions. We should add a
  FENCE.I before uvmcopy() returns.

* NOTE: The current solution only works for a single-processor system.
  According to the RISC-V manual, for a multiprocess system, we should
    1. copy the code (in exec() or uvmcopy())
    2. execute a FENCE instruciton to let the data stream of other harts
       see the copied code
    3. use IPI to notify other harts to execute a FENCE.I to let their
       instruction stream see the copied code