### PR TITLE
Update ramdisk.c

### DIFF
--- a/kernel/ramdisk.c
+++ b/kernel/ramdisk.c
@@ -1,5 +1,5 @@
 //
-// ramdisk that uses the disk image loaded by qemu -rdinit fs.img
+// ramdisk that uses the disk image loaded by qemu -initrd fs.img
 //
 
 #include "types.h"


### PR DESCRIPTION
The qemu syntax for a ram disk was documented incorrectly. The documented syntax is here:
https://qemu.weilnetz.de/doc/qemu-doc.html