### PR TITLE
Write virtio interrupt ack register in virtio_disk_intr()

### DIFF
--- a/kernel/virtio_disk.c
+++ b/kernel/virtio_disk.c
@@ -264,6 +264,7 @@ virtio_disk_intr()
 
     disk.used_idx = (disk.used_idx + 1) % NUM;
   }
+  *R(VIRTIO_MMIO_INTERRUPT_ACK) = *R(VIRTIO_MMIO_INTERRUPT_STATUS) & 0x3;
 
   release(&disk.vdisk_lock);
 }


### PR DESCRIPTION
Hi, I've made [RISC-V emulator written in Rust](https://github.com/takahirox/riscv-rust) which runs xv6 and Linux. It's compiled to WebAssembly so that you can run them even on web browser.

While developing it I found one thing in xv6-riscv virtio block device driver which may not follow the virtio block device specification.

From 4.2.3.4.1 Driver Requirements: Notifications From The Device in [virtio v1.1 specification](https://github.com/mit-pdos/xv6-riscv/blob/riscv/doc/virtio-v1.1-csprd01.pdf),

> After the interrupt is handled, the driver MUST acknowledge it by writing a bit mask corresponding to the handled events to the InterruptACK register.

but xv6-riscv virtio block device driver (virtio_disk_intr()) doesn't write to interruptACK register.

This PR lets the driver write to interruptACK when completing an interrupt handling. I confirmed qemu keeps working with this change.
