### PR TITLE
Explicitly set Virtio disk queue align

### DIFF
--- a/kernel/virtio_disk.c
+++ b/kernel/virtio_disk.c
@@ -97,6 +97,7 @@ virtio_disk_init(void)
   *R(VIRTIO_MMIO_QUEUE_NUM) = NUM;
   memset(disk.pages, 0, sizeof(disk.pages));
   *R(VIRTIO_MMIO_QUEUE_PFN) = ((uint64)disk.pages) >> PGSHIFT;
+  *R(VIRTIO_MMIO_QUEUE_ALIGN) = PGSIZE;
 
   // desc = pages -- num * VRingDesc
   // avail = pages + 0x40 -- 2 * uint16, then num * uint16


### PR DESCRIPTION
xv6-riscv virtio disk driver seems to expect that queue align default value is 4096.

According to [2.6.2 Legacy Interfaces: A Note on Virtqueue Layout in virtio v1.1 specification](https://github.com/mit-pdos/xv6-riscv/blob/riscv/doc/virtio-v1.1-csprd01.pdf), 

> Each virtqueue occupies two or more physically-contiguous pages (usually defined as 4096 bytes, but depending on the transport; henceforth referred to as Queue Align)

it mentions queue align is "usually" defined as 4096 bytes by default so I think it sounds like there might be a chance that it can be non-4096 bytes on some devices.

So I'd like to suggest to explicitly set queue align. In addition to resolve the problem which can cause on non default 4096 queue aligned device, the following inline comment will be clearer to learners, what 4096 is from.

```
  // desc = pages -- num * VRingDesc
  // avail = pages + 0x40 -- 2 * uint16, then num * uint16
  // used = pages + 4096 -- 2 * uint16, then num * vRingUsedElem
```

I confirmed xv6-riscv keeps working on qemu and [my RISC-V emulator](https://github.com/takahirox/riscv-rust) with this change.