### PR TITLE
xv6 kernel level preemption issue

### DIFF
--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -505,6 +505,7 @@ sched(void)
   if(intr_get())
     panic("sched interruptible");
 
+  mycpu()->need_dispatch = 0;  // Clear delayed dispatching flag
   intena = mycpu()->intena;
   swtch(&p->context, &mycpu()->context);
   mycpu()->intena = intena;

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -24,6 +24,7 @@ struct cpu {
   struct context context;     // swtch() here to enter scheduler().
   int noff;                   // Depth of push_off() nesting.
   int intena;                 // Were interrupts enabled before push_off()?
+  int need_dispatch;          // Delayed dispatching flag
 };
 
 extern struct cpu cpus[NCPU];


### PR DESCRIPTION
The xv6 kernel preempts CPU by switching processes after the interrupt is processed, however, it  might be the correct way to postpone the context switch until the currently executing process returns to user space because version6 Unix ensured atomicity for each system call.

In addition to this, if a timer interrupt occurs when the kernel is handling some interrupt, the kernel should postpone the context switch not to suspend interrupt handling. This is needed to ensure the priority between the interrupt and process so that interrupts should be handled prior to processes. 

I wrote a piece of patch to fix this issue.
Would you please apply this patch to xv6 kernel if you can accept this patch. I've tested this patch with risc-v version of xv6 kernel.
