### PR TITLE
Corrects order of UART RX/TX interrupt enable bits

### DIFF
--- a/kernel/uart.c
+++ b/kernel/uart.c
@@ -22,8 +22,8 @@
 #define RHR 0                 // receive holding register (for input bytes)
 #define THR 0                 // transmit holding register (for output bytes)
 #define IER 1                 // interrupt enable register
-#define IER_TX_ENABLE (1<<0)
-#define IER_RX_ENABLE (1<<1)
+#define IER_RX_ENABLE (1<<0)
+#define IER_TX_ENABLE (1<<1)
 #define FCR 2                 // FIFO control register
 #define FCR_FIFO_ENABLE (1<<0)
 #define FCR_FIFO_CLEAR (3<<1) // clear the content of the two FIFOs


### PR DESCRIPTION
(per http://byterunner.com/16550.html and manually tested in qemu bare metal echo)