### PR TITLE
Make kernel entry symbol globally visible

### DIFF
--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -3,6 +3,7 @@
         # kernel.ld causes the following code to
         # be placed at 0x80000000.
 .section .text
+.global  _entry
 _entry:
 	# set up a stack for C.
         # stack0 is declared in start.c,


### PR DESCRIPTION
This fixes issue #27, where the linker couldn't find `_entry` and happened to pick it's location in memory as the default entry location.