### PR TITLE
Adding a tool prefix path for Suse / RHEL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ TOOLPREFIX := $(shell if riscv64-unknown-elf-objdump -i 2>&1 | grep 'elf64-big' 
 	then echo 'riscv64-linux-gnu-'; \
 	elif riscv64-unknown-linux-gnu-objdump -i 2>&1 | grep 'elf64-big' >/dev/null 2>&1; \
 	then echo 'riscv64-unknown-linux-gnu-'; \
+	elif riscv64-elf-objdump -i 2>&1 | grep 'elf64-big' >/dev/null 2>&1; \
+	then echo 'riscv64-elf-'; \
 	else echo "***" 1>&2; \
 	echo "*** Error: Couldn't find a riscv64 version of GCC/binutils." 1>&2; \
 	echo "*** To turn off this error, run 'gmake TOOLPREFIX= ...'." 1>&2; \


### PR DESCRIPTION
The target packages for OpenSUSE / RHEL and friends (presumably Fedora, but I don't run that) put the riscv64 tool prefix as `riscv64-elf-`, specifically the `cross-riscv64-elf-gcc10` package in OpenSUSE (tumbleweed).

I understand if you don't want to support the kitchen sink of distros, but maybe there's another OpenSUSE user out there who could benefit. (I'd also be willing to wirte a few sentences for the setup / tools page on the mit site for this platform)

Thanks for making all of this open source!