### PR TITLE
Set PTE_A and PTE_D when init page table

### DIFF
--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -147,7 +147,7 @@ mappages(pagetable_t pagetable, uint64 va, uint64 size, uint64 pa, int perm)
       return -1;
     if(*pte & PTE_V)
       panic("remap");
-    *pte = PA2PTE(pa) | perm | PTE_V;
+    *pte = PA2PTE(pa) | perm | PTE_V | PTE_A | PTE_D;
     if(a == last)
       break;
     a += PGSIZE;


### PR DESCRIPTION
When access a page without A or write a page without D, hardware have 2 choice
1. raise a exception
2. set bits by core
qemu choose the second way, if we want to run xv6 on spike or others, we should set the bits
Cause at this time, stvec is still 0
Linux also set A and D when init