### PR TITLE
Set PTE_A and PTE_D when init page table entry

### DIFF
--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -331,6 +331,9 @@ sfence_vma()
 #define PTE_W (1L << 2)
 #define PTE_X (1L << 3)
 #define PTE_U (1L << 4) // 1 -> user can access
+#define PTE_G (1L << 5)
+#define PTE_A (1L << 6)
+#define PTE_D (1L << 7)
 
 // shift a physical address to the right place for a PTE.
 #define PA2PTE(pa) ((((uint64)pa) >> 12) << 10)

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -147,7 +147,7 @@ mappages(pagetable_t pagetable, uint64 va, uint64 size, uint64 pa, int perm)
       return -1;
     if(*pte & PTE_V)
       panic("remap");
-    *pte = PA2PTE(pa) | perm | PTE_V;
+    *pte = PA2PTE(pa) | perm | PTE_V | PTE_A | PTE_D;
     if(a == last)
       break;
     a += PGSIZE;


### PR DESCRIPTION
When access a page without A or write a page without D, hardware have 2 choices
1. raise a exception
2. set bits
qemu choose the second way, if we want to run xv6 on spike or others, we should set these bits
Cause at this time, stvec is still 0, and xv6 can not handle page fault
Linux also set A and D when init, so I suggest xv6 follow this design