### PR TITLE
Free the intermediate page created in case of failure

### DIFF
--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -80,16 +80,26 @@ kvminithart()
 pte_t *
 walk(pagetable_t pagetable, uint64 va, int alloc)
 {
+  pte_t *created;
+  
   if(va >= MAXVA)
     panic("walk");
 
-  for(int level = 2; level > 0; level--) {
+  created = 0;
+  for(int level = 2; level > 0; level--){
     pte_t *pte = &pagetable[PX(level, va)];
     if(*pte & PTE_V) {
       pagetable = (pagetable_t)PTE2PA(*pte);
     } else {
-      if(!alloc || (pagetable = (pde_t*)kalloc()) == 0)
+      if(!alloc || (pagetable = (pde_t*)kalloc()) == 0){
+        // Free the already created level 2 PTE.
+        if(created){
+          kfree((void *)PTE2PA(*created));
+          *created = 0;
+        }
         return 0;
+      }
+      created = pte;
       memset(pagetable, 0, PGSIZE);
       *pte = PA2PTE(pagetable) | PTE_V;
     }


### PR DESCRIPTION
If walk() fails because there's not enough memories left, free the
newly created level 2 PTE.