### PR TITLE
exec() only accepts MAXARG arguments

### DIFF
--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -14,7 +14,7 @@ exec(char *path, char **argv)
 {
   char *s, *last;
   int i, off;
-  uint64 argc, sz = 0, sp, ustack[MAXARG+1], stackbase;
+  uint64 argc, sz = 0, sp, ustack[MAXARG], stackbase;
   struct elfhdr elf;
   struct inode *ip;
   struct proghdr ph;


### PR DESCRIPTION
The terminating NULL string is already included (see sys_exec()).