### PR TITLE
Assert that the size in mappages() is always positive

### DIFF
--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -140,13 +140,16 @@ mappages(pagetable_t pagetable, uint64 va, uint64 size, uint64 pa, int perm)
   uint64 a, last;
   pte_t *pte;
 
+  if(size == 0)
+    panic("mappages: size");
+  
   a = PGROUNDDOWN(va);
   last = PGROUNDDOWN(va + size - 1);
   for(;;){
     if((pte = walk(pagetable, a, 1)) == 0)
       return -1;
     if(*pte & PTE_V)
-      panic("remap");
+      panic("mappages: remap");
     *pte = PA2PTE(pa) | perm | PTE_V;
     if(a == last)
       break;


### PR DESCRIPTION
If va % PGSIZE == 0 and size == 0, we have last < a at the start of
the loop so we might never terminate.  That being said, this
particular case couldn't be triggered for now.