### PR TITLE
I think variable pr is unnecessary.

### DIFF
--- a/kernel/console.c
+++ b/kernel/console.c
@@ -11,9 +11,8 @@
 
 #include <stdarg.h>
 
-#include "types.h"
+#include "console.h"
 #include "param.h"
-#include "spinlock.h"
 #include "sleeplock.h"
 #include "fs.h"
 #include "file.h"
@@ -41,16 +40,7 @@ consputc(int c)
   }
 }
 
-struct {
-  struct spinlock lock;
-  
-  // input
-#define INPUT_BUF 128
-  char buf[INPUT_BUF];
-  uint r;  // Read index
-  uint w;  // Write index
-  uint e;  // Edit index
-} cons;
+struct console cons;
 
 //
 // user write()s to the console go here.
@@ -174,8 +164,9 @@ consoleintr(int c)
     }
     break;
   }
-  
-  release(&cons.lock);
+  if (holding(&cons.lock)){
+    release(&cons.lock);
+  }
 }
 
 void
@@ -189,4 +180,5 @@ consoleinit(void)
   // to consoleread and consolewrite.
   devsw[CONSOLE].read = consoleread;
   devsw[CONSOLE].write = consolewrite;
+  cons.locking = 1;
 }

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -164,9 +164,8 @@ consoleintr(int c)
     }
     break;
   }
-  if (holding(&cons.lock)){
+  if (holding(&cons.lock))
     release(&cons.lock);
-  }
 }
 
 void

--- a/kernel/console.h
+++ b/kernel/console.h
@@ -1,0 +1,15 @@
+#include "types.h"
+#include "spinlock.h"
+
+struct console {
+  struct spinlock lock;
+  
+  // input
+#define INPUT_BUF 128
+  char buf[INPUT_BUF];
+  uint r;  // Read index
+  uint w;  // Write index
+  uint e;  // Edit index
+
+  int locking;
+};

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -12,7 +12,6 @@ main()
 {
   if(cpuid() == 0){
     consoleinit();
-    printfinit();
     printf("\n");
     printf("xv6 kernel is booting\n");
     printf("\n");

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -5,8 +5,6 @@
 #include <stdarg.h>
 
 #include "console.h"
-// #include "spinlock.h"
-// #include "types.h"
 #include "param.h"
 #include "spinlock.h"
 #include "sleeplock.h"

--- a/kernel/spinlock.h
+++ b/kernel/spinlock.h
@@ -1,3 +1,6 @@
+#ifndef SPINLOCK_H
+#define SPINLOCK_H
+
 // Mutual exclusion lock.
 struct spinlock {
   uint locked;       // Is the lock held?
@@ -7,3 +10,4 @@ struct spinlock {
   struct cpu *cpu;   // The cpu holding the lock.
 };
 
+#endif


### PR DESCRIPTION
Can I ask if there exist any major intention of using variable `pr` and separated locks `pr.lock` and `cons.lock`?
If it is just to avoid panic when we call `consoleintr->procdump->printf`, I suggest these changes.