### PR TITLE
Exit with failure code

### DIFF
--- a/user/rm.c
+++ b/user/rm.c
@@ -15,7 +15,7 @@ main(int argc, char *argv[])
   for(i = 1; i < argc; i++){
     if(unlink(argv[i]) < 0){
       fprintf(2, "rm: %s failed to delete\n", argv[i]);
-      break;
+      exit(1);
     }
   }
 

--- a/user/sh.c
+++ b/user/sh.c
@@ -77,7 +77,7 @@ runcmd(struct cmd *cmd)
       exit(1);
     exec(ecmd->argv[0], ecmd->argv);
     fprintf(2, "exec %s failed\n", ecmd->argv[0]);
-    break;
+    exit(1);
 
   case REDIR:
     rcmd = (struct redircmd*)cmd;


### PR DESCRIPTION
when

  * failed to unlink in `rm`
  * failed to run command in `sh`
