### PR TITLE
Change `inode cache` in main.c to `inode table`

### DIFF
--- a/kernel/main.c
+++ b/kernel/main.c
@@ -25,7 +25,7 @@ main()
     plicinit();      // set up interrupt controller
     plicinithart();  // ask PLIC for device interrupts
     binit();         // buffer cache
-    iinit();         // inode cache
+    iinit();         // inode table
     fileinit();      // file table
     virtio_disk_init(); // emulated hard disk
     userinit();      // first user process


### PR DESCRIPTION
As https://github.com/mit-pdos/xv6-riscv/commit/077323a8f0b3440fcc3d082096a2d83fe5461d70 renamed `icache` to `itable`, I think `// inode cache` comment in main.c should be modified to `// inode table`.