### PR TITLE
[Closes #27] Remove linker warning

### DIFF
--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -3,6 +3,7 @@
         # kernel.ld causes the following code to
         # be placed at 0x80000000.
 .section .text
+.globl _entry
 _entry:
 	# set up a stack for C.
         # stack0 is declared in start.c,


### PR DESCRIPTION
- Closes #27 
- Although xv6 works well, the following linker warning occurs when executing 'make qemu'.
```
riscv64-linux-gnu-ld -z max-page-size=4096 -T kernel/kernel.ld -o kernel/kernel kernel/entry.o kernel/start.o kernel/console.o kernel/printf.o kernel/uart.o kernel/kalloc.o kernel/spinlock.o kernel/string.o kernel/main.o kernel/vm.o kernel/proc.o kernel/swtch.o kernel/trampoline.o kernel/trap.o kernel/syscall.o kernel/sysproc.o kernel/bio.o kernel/fs.o kernel/log.o kernel/sleeplock.o kernel/file.o kernel/pipe.o kernel/exec.o kernel/sysfile.o kernel/kernelvec.o kernel/plic.o kernel/virtio_disk.o 
riscv64-linux-gnu-ld: warning: cannot find entry symbol _entry; defaulting to 0000000080000000
```
- As @judearich said, putting a .global _entry directive in kernel/entry.S fixes the problem and removes the linker warning.