### PR TITLE
Exit from start() by restoring the sp correctly, before jumping to main()

### DIFF
--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -16,5 +16,8 @@ _entry:
         add sp, sp, a0
 	# jump to start() in start.c
         call start
+        # start() in start.c would have set the mepc to main()
+        # switch to supervisor mode and jump to main().
+        mret
 spin:
         j spin

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -44,9 +44,6 @@ start()
   // keep each CPU's hartid in its tp register, for cpuid().
   int id = r_mhartid();
   w_tp(id);
-
-  // switch to supervisor mode and jump to main().
-  asm volatile("mret");
 }
 
 // set up to receive timer interrupts in machine mode,


### PR DESCRIPTION
using asm volatile("mret") in start() leads to a jump to main()
before the stack pointer is adjusted back by 16. Result is wasted 16 bytes.

Without the fix:
```
│   0x800000e6 <start+88>           mv      tp,a5
│   0x800000e8 <start+90>           mret    # jump to main() here
│   0x800000ec <start+94>           ld      ra,8(sp)
│   0x800000ee <start+96>           ld      s0,0(sp)
│   0x800000f0 <start+98>           addi    sp,sp,16
│   0x800000f2 <start+100>          ret
```

With the fix:
```
│   0x800000e4 <start+82>           csrr    a5,mhartid
│   0x800000e8 <start+86>           sext.w  a5,a5
│   0x800000ea <start+88>           mv      tp,a5
│   0x800000ec <start+90>           ld      ra,8(sp)
│   0x800000ee <start+92>           ld      s0,0(sp)
│   0x800000f0 <start+94>           addi    sp,sp,16
│   0x800000f2 <start+96>           ret
```
Return address (ra) when in start()
```
│ra             0x8000001a       0x8000001a <_entry+26>
```

Instruction at 0x8000001a
```
│   0x8000001a <_entry+26>          mret  # jump to main here (from within _entry)
```
Signed-off-by: Piyush Itankar <pitankar@gmail.com>