### PR TITLE
Remove setproc prototype

### DIFF
--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -96,7 +96,6 @@ struct proc*    myproc();
 void            procinit(void);
 void            scheduler(void) __attribute__((noreturn));
 void            sched(void);
-void            setproc(struct proc*);
 void            sleep(void*, struct spinlock*);
 void            userinit(void);
 int             wait(uint64);


### PR DESCRIPTION
`setproc` is declared, but never defined or called from anywhere.