### PR TITLE
fix comment for 'sepc'

### DIFF
--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -111,7 +111,7 @@ w_mie(uint64 x)
   asm volatile("csrw mie, %0" : : "r" (x));
 }
 
-// machine exception program counter, holds the
+// supervisor exception program counter, holds the
 // instruction address to which a return from
 // exception will go.
 static inline void 


### PR DESCRIPTION
w_sepc() function has a comment which incorrectly mentions "machine exception program counter" -- instead of "supervisor exception program counter". This PR fixes it.