### PR TITLE
Add flags when compiling assembly files too.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ CFLAGS += -fno-pie -nopie
 endif
 
 LDFLAGS = -z max-page-size=4096
+ASFLAGS = $(CFLAGS)
 
 $K/kernel: $(OBJS) $K/kernel.ld $U/initcode
 	$(LD) $(LDFLAGS) -T $K/kernel.ld -o $K/kernel $(OBJS) 


### PR DESCRIPTION
This prevents a miscompilation due to position independent code.
The first instruction sequence, to load stack0 into sp, is incorrect.