### PR TITLE
Add acquire p->lock to safely reference p->killed.

### DIFF
--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -417,10 +417,13 @@ wait(uint64 addr)
     }
 
     // No point waiting if we don't have any children.
+    acquire(&p->lock);
     if(!havekids || p->killed){
+      release(&p->lock);
       release(&wait_lock);
       return -1;
     }
+    release(&p->lock);
     
     // Wait for a child to exit.
     sleep(p, &wait_lock);  //DOC: wait-sleep


### PR DESCRIPTION
According to the comments in proc.h, I think p->lock is needed to reference p->killed, but is it not needed?