### PR TITLE
Add support for running under OpenSBI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ ifndef CPUS
 CPUS := 3
 endif
 
-QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic
+QEMUOPTS = -machine virt -bios default -kernel $K/kernel -m 128M -smp $(CPUS) -nographic
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/sbi.o
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -105,6 +105,9 @@ int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);
 int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
 
+// sbi.c
+void            sbiinit(void);
+
 // swtch.S
 void            swtch(struct context*, struct context*);
 

--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -1,7 +1,7 @@
-	# qemu -kernel loads the kernel at 0x80000000
+	# qemu -kernel loads the kernel at 0x80200000
         # and causes each CPU to jump there.
         # kernel.ld causes the following code to
-        # be placed at 0x80000000.
+        # be placed at 0x80200000.
 .section .text
 .global _entry
 _entry:

--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -5,16 +5,19 @@
 .section .text
 .global _entry
 _entry:
+        # OpenSBI sets up the following registers:
+        #   a0 = hartid
+        #   a1 = pointer to fdt
+        #
 	# set up a stack for C.
         # stack0 is declared in start.c,
         # with a 4096-byte stack per CPU.
         # sp = stack0 + (hartid * 4096)
         la sp, stack0
-        li a0, 1024*4
-	csrr a1, mhartid
-        addi a1, a1, 1
-        mul a0, a0, a1
-        add sp, sp, a0
+        li a2, 1024*4
+        addi a3, a0, 1
+        mul a2, a2, a3
+        add sp, sp, a2
 	# jump to start() in start.c
         call start
 spin:

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -4,10 +4,10 @@ ENTRY( _entry )
 SECTIONS
 {
   /*
-   * ensure that entry.S / _entry is at 0x80000000,
+   * ensure that entry.S / _entry is at 0x80200000,
    * where qemu's -kernel jumps.
    */
-  . = 0x80000000;
+  . = 0x80200000;
 
   .text : {
     *(.text .text.*)

--- a/kernel/kernelvec.S
+++ b/kernel/kernelvec.S
@@ -84,38 +84,3 @@ kernelvec:
 
         // return to whatever we were doing in the kernel.
         sret
-
-        #
-        # machine-mode timer interrupt.
-        #
-.globl timervec
-.align 4
-timervec:
-        # start.c has set up the memory that mscratch points to:
-        # scratch[0,8,16] : register save area.
-        # scratch[24] : address of CLINT's MTIMECMP register.
-        # scratch[32] : desired interval between interrupts.
-        
-        csrrw a0, mscratch, a0
-        sd a1, 0(a0)
-        sd a2, 8(a0)
-        sd a3, 16(a0)
-
-        # schedule the next timer interrupt
-        # by adding interval to mtimecmp.
-        ld a1, 24(a0) # CLINT_MTIMECMP(hart)
-        ld a2, 32(a0) # interval
-        ld a3, 0(a1)
-        add a3, a3, a2
-        sd a3, 0(a1)
-
-        # raise a supervisor software interrupt.
-	li a1, 2
-        csrw sip, a1
-
-        ld a3, 16(a0)
-        ld a2, 8(a0)
-        ld a1, 0(a0)
-        csrrw a0, mscratch, a0
-
-        mret

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -16,6 +16,7 @@ main()
     printf("\n");
     printf("xv6 kernel is booting\n");
     printf("\n");
+    sbiinit();
     kinit();         // physical page allocator
     kvminit();       // create kernel page table
     kvminithart();   // turn on paging

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -8,12 +8,13 @@
 // 0C000000 -- PLIC
 // 10000000 -- uart0 
 // 10001000 -- virtio disk 
-// 80000000 -- boot ROM jumps here in machine mode
+// 80000000 -- OpenSBI M-mode firmware
+// 80200000 -- OpenSBI jumps here in S-mode
 //             -kernel loads the kernel here
-// unused RAM after 80000000.
+// unused RAM after 80200000.
 
 // the kernel uses physical memory thus:
-// 80000000 -- entry.S, then kernel text and data
+// 80200000 -- entry.S, then kernel text and data
 // end -- start of kernel page allocation area
 // PHYSTOP -- end RAM used by the kernel
 
@@ -43,9 +44,9 @@
 
 // the kernel expects there to be RAM
 // for use by the kernel and user pages
-// from physical address 0x80000000 to PHYSTOP.
-#define KERNBASE 0x80000000L
-#define PHYSTOP (KERNBASE + 128*1024*1024)
+// from physical address 0x80200000 to PHYSTOP.
+#define KERNBASE 0x80200000L
+#define PHYSTOP (KERNBASE + 126*1024*1024)
 
 // map the trampoline page to the highest address,
 // in both user and kernel space.

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -1,43 +1,3 @@
-// which hart (core) is this?
-static inline uint64
-r_mhartid()
-{
-  uint64 x;
-  asm volatile("csrr %0, mhartid" : "=r" (x) );
-  return x;
-}
-
-// Machine Status Register, mstatus
-
-#define MSTATUS_MPP_MASK (3L << 11) // previous mode.
-#define MSTATUS_MPP_M (3L << 11)
-#define MSTATUS_MPP_S (1L << 11)
-#define MSTATUS_MPP_U (0L << 11)
-#define MSTATUS_MIE (1L << 3)    // machine-mode interrupt enable.
-
-static inline uint64
-r_mstatus()
-{
-  uint64 x;
-  asm volatile("csrr %0, mstatus" : "=r" (x) );
-  return x;
-}
-
-static inline void 
-w_mstatus(uint64 x)
-{
-  asm volatile("csrw mstatus, %0" : : "r" (x));
-}
-
-// machine exception program counter, holds the
-// instruction address to which a return from
-// exception will go.
-static inline void 
-w_mepc(uint64 x)
-{
-  asm volatile("csrw mepc, %0" : : "r" (x));
-}
-
 // Supervisor Status Register, sstatus
 
 #define SSTATUS_SPP (1L << 8)  // Previous mode, 1=Supervisor, 0=User
@@ -93,24 +53,6 @@ w_sie(uint64 x)
   asm volatile("csrw sie, %0" : : "r" (x));
 }
 
-// Machine-mode Interrupt Enable
-#define MIE_MEIE (1L << 11) // external
-#define MIE_MTIE (1L << 7)  // timer
-#define MIE_MSIE (1L << 3)  // software
-static inline uint64
-r_mie()
-{
-  uint64 x;
-  asm volatile("csrr %0, mie" : "=r" (x) );
-  return x;
-}
-
-static inline void 
-w_mie(uint64 x)
-{
-  asm volatile("csrw mie, %0" : : "r" (x));
-}
-
 // supervisor exception program counter, holds the
 // instruction address to which a return from
 // exception will go.
@@ -128,36 +70,6 @@ r_sepc()
   return x;
 }
 
-// Machine Exception Delegation
-static inline uint64
-r_medeleg()
-{
-  uint64 x;
-  asm volatile("csrr %0, medeleg" : "=r" (x) );
-  return x;
-}
-
-static inline void 
-w_medeleg(uint64 x)
-{
-  asm volatile("csrw medeleg, %0" : : "r" (x));
-}
-
-// Machine Interrupt Delegation
-static inline uint64
-r_mideleg()
-{
-  uint64 x;
-  asm volatile("csrr %0, mideleg" : "=r" (x) );
-  return x;
-}
-
-static inline void 
-w_mideleg(uint64 x)
-{
-  asm volatile("csrw mideleg, %0" : : "r" (x));
-}
-
 // Supervisor Trap-Vector Base Address
 // low two bits are mode.
 static inline void 
@@ -172,25 +84,6 @@ r_stvec()
   uint64 x;
   asm volatile("csrr %0, stvec" : "=r" (x) );
   return x;
-}
-
-// Machine-mode interrupt vector
-static inline void 
-w_mtvec(uint64 x)
-{
-  asm volatile("csrw mtvec, %0" : : "r" (x));
-}
-
-static inline void
-w_pmpcfg0(uint64 x)
-{
-  asm volatile("csrw pmpcfg0, %0" : : "r" (x));
-}
-
-static inline void
-w_pmpaddr0(uint64 x)
-{
-  asm volatile("csrw pmpaddr0, %0" : : "r" (x));
 }
 
 // use riscv's sv39 page table scheme.
@@ -221,12 +114,6 @@ w_sscratch(uint64 x)
   asm volatile("csrw sscratch, %0" : : "r" (x));
 }
 
-static inline void 
-w_mscratch(uint64 x)
-{
-  asm volatile("csrw mscratch, %0" : : "r" (x));
-}
-
 // Supervisor Trap Cause
 static inline uint64
 r_scause()
@@ -245,22 +132,7 @@ r_stval()
   return x;
 }
 
-// Machine-mode Counter-Enable
-static inline void 
-w_mcounteren(uint64 x)
-{
-  asm volatile("csrw mcounteren, %0" : : "r" (x));
-}
-
-static inline uint64
-r_mcounteren()
-{
-  uint64 x;
-  asm volatile("csrr %0, mcounteren" : "=r" (x) );
-  return x;
-}
-
-// machine-mode cycle counter
+// supervisor-mode cycle counter
 static inline uint64
 r_time()
 {

--- a/kernel/sbi.c
+++ b/kernel/sbi.c
@@ -1,0 +1,105 @@
+#include "types.h"
+#include "riscv.h"
+#include "defs.h"
+#include "sbi.h"
+
+void _entry();
+
+struct sbiret sbi_ecall(int ext, int fid, uint64 arg0, uint64 arg1, 
+        uint64 arg2, uint64 arg3, uint64 arg4, uint64 arg5)
+{
+	struct sbiret ret;
+
+	register uint64 a0 asm ("a0") = arg0;
+	register uint64 a1 asm ("a1") = arg1;
+	register uint64 a2 asm ("a2") = arg2;
+	register uint64 a3 asm ("a3") = arg3;
+	register uint64 a4 asm ("a4") = arg4;
+	register uint64 a5 asm ("a5") = arg5;
+	register uint64 a6 asm ("a6") = fid;
+	register uint64 a7 asm ("a7") = ext;
+	asm volatile ("ecall"
+		      : "+r" (a0), "+r" (a1)
+		      : "r" (a2), "r" (a3), "r" (a4), "r" (a5), "r" (a6), "r" (a7)
+		      : "memory");
+
+	ret.error = a0;
+	ret.value = a1;
+
+	return ret;
+}
+
+static inline long sbi_get_spec_version(void)
+{
+	struct sbiret ret;
+
+	ret = sbi_ecall(SBI_EXT_ID_BASE, SBI_BASE_GET_SPEC_VERSION, 0, 0, 0, 0, 0, 0);
+	if (ret.error) {
+		panic("sbi_get_spec_version failed");		
+	}
+	return ret.value;
+}
+
+static inline long sbi_probe_extension(int extid)
+{
+	struct sbiret ret;
+
+	ret = sbi_ecall(SBI_EXT_ID_BASE, SBI_BASE_PROBE_EXTENSION, extid, 0, 0, 0, 0, 0);
+	if (ret.error) {
+		return ret.error;
+	}
+    return ret.value;
+}
+
+static inline long sbi_hart_start(uint64 hartid, uint64 saddr, uint64 priv)
+{
+	struct sbiret ret;
+
+	ret = sbi_ecall(SBI_EXT_ID_HSM, SBI_HSM_HART_START, hartid, saddr, priv, 0, 0, 0);
+	if (ret.error) {
+		return ret.error;
+	}
+    return ret.value;
+}
+
+void sbiinit(void)
+{
+    uint64 version = sbi_get_spec_version();
+	uint64 major = (version >> SBI_SPEC_VERSION_MAJOR_SHIFT) &
+	        SBI_SPEC_VERSION_MAJOR_MASK;
+	uint64 minor = version & SBI_SPEC_VERSION_MINOR_MASK;
+    printf("SBI specification v%d.%d detected\n", major, minor);
+
+	if (sbi_probe_extension(SBI_EXT_ID_TIME) > 0) {
+		printf("SBI TIME extension detected\n");
+	}
+
+	if (sbi_probe_extension(SBI_EXT_ID_IPI) > 0) {
+		printf("SBI IPI extension detected\n");
+	}
+
+	if (sbi_probe_extension(SBI_EXT_ID_RFNC) > 0) {
+		printf("SBI RFNC extension detected\n");
+	}
+
+	if (sbi_probe_extension(SBI_EXT_ID_HSM) > 0) {
+		printf("SBI HSM extension detected\n");
+
+		uint64 ret = SBI_SUCCESS;
+		uint64 hartid = 1;
+		while (ret == SBI_SUCCESS) {
+			ret = sbi_hart_start(hartid, (uint64)_entry, 0);
+			hartid++;
+		}
+	}
+
+	if (sbi_probe_extension(SBI_EXT_ID_SRST) > 0) {
+		printf("SBI SRST extension detected\n");
+	}
+
+	if (sbi_probe_extension(SBI_EXT_ID_PMU) > 0) {
+		printf("SBI PMU extension detected\n");
+	}
+
+	printf("\n");
+}

--- a/kernel/sbi.h
+++ b/kernel/sbi.h
@@ -1,0 +1,67 @@
+/* SBI Base Extension */
+#define SBI_EXT_ID_BASE              0x10
+#define SBI_BASE_GET_SPEC_VERSION    0
+#define SBI_BASE_GET_IMPL_ID         1
+#define SBI_BASE_GET_IMPL_VERSION    2
+#define SBI_BASE_PROBE_EXTENSION     3
+#define SBI_BASE_GET_MVENDORID       4
+#define SBI_BASE_GET_MARCHID         5
+#define SBI_BASE_GET_MIMPID          6
+
+/* Timer (TIME) Extension */
+#define SBI_EXT_ID_TIME       0x54494D45
+#define SBI_TIME_SET_TIMER    0
+
+/* S-mode IPI (IPI) Extension */
+#define SBI_EXT_ID_IPI      0x735049
+#define SBI_IPI_SEND_IPI    0
+
+/* RFENCE (RFNC) Extension */
+#define SBI_EXT_ID_RFNC                     0x52464E43
+#define SBI_RFNC_REMOTE_FENCE_I             0
+#define SBI_RFNC_REMOTE_SFENCE_VMA          1
+#define SBI_RFNC_REMOTE_SFENCE_VMA_ASID     2
+#define SBI_RFNC_REMOTE_HFENCE_GVMA_VMID    3
+#define SBI_RFNC_REMOTE_HFENCE_GVMA         4
+#define SBI_RFNC_REMOTE_HFENCE_VVMA_ASID    5
+#define SBI_RFNC_REMOTE_HFENCE_VVMA         6
+
+/* Hart State Management (HSM) Extension */
+#define SBI_EXT_ID_HSM         0x48534D
+#define SBI_HSM_HART_START     0
+#define SBI_HSM_HART_STOP      1
+#define SBI_HSM_HART_STATUS    2
+#define SBI_HSM_HART_SUSPEND   3
+
+/* System Reset (SRST) Extension */
+#define SBI_EXT_ID_SRST          0x53525354
+#define SBI_SRST_SYSTEM_RESET    0
+
+/* Performance Monitoring Unit (PMU) Extension */
+#define SBI_EXT_ID_PMU                     0x504D55
+#define SBI_PMU_NUM_COUNTERS               0
+#define SBI_PMU_COUNTER_GET_INFO           1
+#define SBI_PMU_COUNTER_CONFIG_MATCHING    2
+#define SBI_PMU_COUNTER_START              3
+#define SBI_PMU_COUNTER_STOP               4
+#define SBI_PMU_COUNTER_FW_READ            5
+
+/* SBI return error codes */
+#define SBI_SUCCESS                 0
+#define SBI_ERR_FAILED              -1
+#define SBI_ERR_NOT_SUPPORTED       -2
+#define SBI_ERR_INVALID_PARAM       -3
+#define SBI_ERR_DENIED              -4
+#define SBI_ERR_INVALID_ADDRESS     -5
+#define SBI_ERR_ALREADY_AVAILABLE   -6
+#define SBI_ERR_ALREADY_STARTED     -7
+#define SBI_ERR_ALREADY_STOPPED     -8
+
+#define SBI_SPEC_VERSION_MAJOR_SHIFT    24
+#define SBI_SPEC_VERSION_MAJOR_MASK     0x7f
+#define SBI_SPEC_VERSION_MINOR_MASK     0xffffff
+
+struct sbiret {
+	long error;
+	long value;
+};

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -3,86 +3,26 @@
 #include "memlayout.h"
 #include "riscv.h"
 #include "defs.h"
+#include "sbi.h"
 
 void main();
-void timerinit();
 
 // entry.S needs one stack per CPU.
 __attribute__ ((aligned (16))) char stack0[4096 * NCPU];
 
-// a scratch area per CPU for machine-mode timer interrupts.
-uint64 timer_scratch[NCPU][5];
-
-// assembly code in kernelvec.S for machine-mode timer interrupt.
-extern void timervec();
-
-// entry.S jumps here in machine mode on stack0.
+// entry.S jumps here in supervisor mode on stack0.
 void
-start()
+start(uint64 hartid, uint64 fdt)
 {
-  // set M Previous Privilege mode to Supervisor, for mret.
-  unsigned long x = r_mstatus();
-  x &= ~MSTATUS_MPP_MASK;
-  x |= MSTATUS_MPP_S;
-  w_mstatus(x);
-
-  // set M Exception Program Counter to main, for mret.
-  // requires gcc -mcmodel=medany
-  w_mepc((uint64)main);
-
   // disable paging for now.
   w_satp(0);
 
-  // delegate all interrupts and exceptions to supervisor mode.
-  w_medeleg(0xffff);
-  w_mideleg(0xffff);
+  // enable interrupts.
   w_sie(r_sie() | SIE_SEIE | SIE_STIE | SIE_SSIE);
 
-  // configure Physical Memory Protection to give supervisor mode
-  // access to all of physical memory.
-  w_pmpaddr0(0x3fffffffffffffull);
-  w_pmpcfg0(0xf);
+  // keep each CPU's hartid in its tp register.
+  w_tp(hartid);
 
-  // ask for clock interrupts.
-  timerinit();
-
-  // keep each CPU's hartid in its tp register, for cpuid().
-  int id = r_mhartid();
-  w_tp(id);
-
-  // switch to supervisor mode and jump to main().
-  asm volatile("mret");
-}
-
-// set up to receive timer interrupts in machine mode,
-// which arrive at timervec in kernelvec.S,
-// which turns them into software interrupts for
-// devintr() in trap.c.
-void
-timerinit()
-{
-  // each CPU has a separate source of timer interrupts.
-  int id = r_mhartid();
-
-  // ask the CLINT for a timer interrupt.
-  int interval = 1000000; // cycles; about 1/10th second in qemu.
-  *(uint64*)CLINT_MTIMECMP(id) = *(uint64*)CLINT_MTIME + interval;
-
-  // prepare information in scratch[] for timervec.
-  // scratch[0..2] : space for timervec to save registers.
-  // scratch[3] : address of CLINT MTIMECMP register.
-  // scratch[4] : desired interval (in cycles) between timer interrupts.
-  uint64 *scratch = &timer_scratch[id][0];
-  scratch[3] = CLINT_MTIMECMP(id);
-  scratch[4] = interval;
-  w_mscratch((uint64)scratch);
-
-  // set the machine-mode trap handler.
-  w_mtvec((uint64)timervec);
-
-  // enable machine-mode interrupts.
-  w_mstatus(r_mstatus() | MSTATUS_MIE);
-
-  // enable machine-mode timer interrupts.
-  w_mie(r_mie() | MIE_MTIE);
+  // Jump to main
+  main();
 }

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -202,7 +202,7 @@ devintr()
     return 1;
   } else if(scause == 0x8000000000000001L){
     // software interrupt from a machine-mode timer interrupt,
-    // forwarded by timervec in kernelvec.S.
+    // forwarded by OpenSBI.
 
     if(cpuid() == 0){
       clockintr();

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -26,7 +26,7 @@ char buf[BUFSZ];
 void
 copyin(char *s)
 {
-  uint64 addrs[] = { 0x80000000LL, 0xffffffffffffffff };
+  uint64 addrs[] = { 0x80200000LL, 0xffffffffffffffff };
 
   for(int ai = 0; ai < 2; ai++){
     uint64 addr = addrs[ai];
@@ -70,7 +70,7 @@ copyin(char *s)
 void
 copyout(char *s)
 {
-  uint64 addrs[] = { 0x80000000LL, 0xffffffffffffffff };
+  uint64 addrs[] = { 0x80200000LL, 0xffffffffffffffff };
 
   for(int ai = 0; ai < 2; ai++){
     uint64 addr = addrs[ai];
@@ -111,7 +111,7 @@ copyout(char *s)
 void
 copyinstr1(char *s)
 {
-  uint64 addrs[] = { 0x80000000LL, 0xffffffffffffffff };
+  uint64 addrs[] = { 0x80200000LL, 0xffffffffffffffff };
 
   for(int ai = 0; ai < 2; ai++){
     uint64 addr = addrs[ai];


### PR DESCRIPTION
[OpenSBI](https://github.com/riscv-software-src/opensbi) is the default bios used for RISC-V running under qemu. This change adds support for enabling the default bios and modifying the start up code of xv6 to support it. I created this change as a way to test out the functionality of OpenSBI but I think it might be a worthwhile change for others as well. OpenSBI is quickly becoming the default on real RISC-V hardware. Having support here opens the possibility of running xv6 on low cost RISC-V hardware in the future.

One note, there are currently four usertests that seem to hang the system

* forkforkfork
* openiput
* killstatus
* preempt

I believe that all of these are actually broken in the main branch as well and show up in this change due to the change in the timer code. If I tweak the timer in the main branch from 1/10 of a second to something else I can get these same tests to hang. Before I spend time digging into the root issue with these tests though I wanted to submit this pull request and see if there was sufficient interest in having these OpenSBI changes merged into the original project.