### PR TITLE
Resolving error "riscv64-linux-gnu-gas: Command not found"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 QEMU = qemu-system-riscv64
 
 CC = $(TOOLPREFIX)gcc
-AS = $(TOOLPREFIX)gas
+AS = $(TOOLPREFIX)as
 LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump


### PR DESCRIPTION
I accidentally used `.s` instead of `.S` when naming a new RISC-V assembly file, and I got the following error.
```
riscv64-linux-gnu-gas -I.  -o user/hi_asm_puts.o user/hi_asm_puts.s
make: riscv64-linux-gnu-gas: Command not found
make: *** [<builtin>: user/hi_asm_puts.o] Error 127
```
I explored the folder containing the binaries for RISC-V, and I found that there was a file called `as`, but not one called `gas`. I thought maybe I accidentally added the 'g' in the Makefile, so I made the following adjustment to the code:
`AS = $(TOOLPREFIX)gas` -> `AS = $(TOOLPREFIX)as`

After that, `make qemu` worked, and my file worked as intended. However, I checked the Makefile of the original repository, and it seems that the original file had `AS = $(TOOLPREFIX)gas`. If this wasn't a mistake, and this is the desired behavior when a file's extension is `.s`, this pull request should be ignored.