### PR TITLE
[user/ls]: List specific device file

### DIFF
--- a/user/ls.c
+++ b/user/ls.c
@@ -42,6 +42,7 @@ ls(char *path)
   }
 
   switch(st.type){
+  case T_DEVICE:
   case T_FILE:
     printf("%s %d %d %l\n", fmtname(path), st.type, st.ino, st.size);
     break;


### PR DESCRIPTION
When using the ls userspace program to list a specific device file,
nothing would be displayed. This was because ls only tests for T_FILE
and T_DIR. T_DEVICE files would fall through the case block.

Adding T_DEVICE to the T_FILE case allows a device file to be listed.

    $ ls console
    console        3 19 0