### PR TITLE
fix 'kfree' comment in kalloc.c

### DIFF
--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -39,7 +39,7 @@ freerange(void *pa_start, void *pa_end)
     kfree(p);
 }
 
-// Free the page of physical memory pointed at by v,
+// Free the page of physical memory pointed at by pa,
 // which normally should have been returned by a
 // call to kalloc().  (The exception is when
 // initializing the allocator; see kinit above.)


### PR DESCRIPTION
'kfree' has a parameter named 'pa' but is referenced in the comment as 'v'.