### PR TITLE
sys_sbrk variable addr overflow

### DIFF
--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -41,7 +41,7 @@ sys_wait(void)
 uint64
 sys_sbrk(void)
 {
-  int addr;
+  uint64 addr;
   int n;
 
   if(argint(0, &n) < 0)


### PR DESCRIPTION
avoid addr (could be larger than MAXINT) overflow