### PR TITLE
No need to store TRAPFRAME in sscratch register

### DIFF
--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -47,6 +47,34 @@
 #define KERNBASE 0x80000000L
 #define PHYSTOP (KERNBASE + 128*1024*1024)
 
+#define PGSIZE 4096 // bytes per page
+#define PGSHIFT 12  // bits of offset within a page
+
+#define PGROUNDUP(sz)  (((sz)+PGSIZE-1) & ~(PGSIZE-1))
+#define PGROUNDDOWN(a) (((a)) & ~(PGSIZE-1))
+
+#define PTE_V (1L << 0) // valid
+#define PTE_R (1L << 1)
+#define PTE_W (1L << 2)
+#define PTE_X (1L << 3)
+#define PTE_U (1L << 4) // 1 -> user can access
+
+// shift a physical address to the right place for a PTE.
+#define PA2PTE(pa) ((((uint64)pa) >> 12) << 10)
+#define PTE2PA(pte) (((pte) >> 10) << 12)
+#define PTE_FLAGS(pte) ((pte) & 0x3FF)
+
+// extract the three 9-bit page table indices from a virtual address.
+#define PXMASK          0x1FF // 9 bits
+#define PXSHIFT(level)  (PGSHIFT+(9*(level)))
+#define PX(level, va) ((((uint64) (va)) >> PXSHIFT(level)) & PXMASK)
+
+// one beyond the highest possible virtual address.
+// MAXVA is actually one bit less than the max allowed by
+// Sv39, to avoid having to sign-extend virtual addresses
+// that have the high bit set.
+#define MAXVA (1L << (9 + 9 + 9 + 12 - 1))
+
 // map the trampoline page to the highest address,
 // in both user and kernel space.
 #define TRAMPOLINE (MAXVA - PGSIZE)

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -331,36 +331,5 @@ sfence_vma()
   asm volatile("sfence.vma zero, zero");
 }
 
-
-#define PGSIZE 4096 // bytes per page
-#define PGSHIFT 12  // bits of offset within a page
-
-#define PGROUNDUP(sz)  (((sz)+PGSIZE-1) & ~(PGSIZE-1))
-#define PGROUNDDOWN(a) (((a)) & ~(PGSIZE-1))
-
-#define PTE_V (1L << 0) // valid
-#define PTE_R (1L << 1)
-#define PTE_W (1L << 2)
-#define PTE_X (1L << 3)
-#define PTE_U (1L << 4) // 1 -> user can access
-
-// shift a physical address to the right place for a PTE.
-#define PA2PTE(pa) ((((uint64)pa) >> 12) << 10)
-
-#define PTE2PA(pte) (((pte) >> 10) << 12)
-
-#define PTE_FLAGS(pte) ((pte) & 0x3FF)
-
-// extract the three 9-bit page table indices from a virtual address.
-#define PXMASK          0x1FF // 9 bits
-#define PXSHIFT(level)  (PGSHIFT+(9*(level)))
-#define PX(level, va) ((((uint64) (va)) >> PXSHIFT(level)) & PXMASK)
-
-// one beyond the highest possible virtual address.
-// MAXVA is actually one bit less than the max allowed by
-// Sv39, to avoid having to sign-extend virtual addresses
-// that have the high bit set.
-#define MAXVA (1L << (9 + 9 + 9 + 12 - 1))
-
 typedef uint64 pte_t;
 typedef uint64 *pagetable_t; // 512 PTEs

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -15,6 +15,7 @@
 #include "sleeplock.h"
 #include "file.h"
 #include "fcntl.h"
+#include "memlayout.h"
 
 // Fetch the nth word-sized system call argument as a file descriptor
 // and return both the descriptor and the corresponding struct file.

--- a/kernel/trampoline.S
+++ b/kernel/trampoline.S
@@ -1,32 +1,58 @@
-	#
+#include "memlayout.h"
+
+        # 0x40000000000 +------------+          +------------+          +------------+
+        #               | trampoline |          |            |          | trampoline |
+        # 0x3fffffff000 +------------+----+     |            |     +----+------------+
+        #               | trapframe  |    |     |            |     |    |            |
+        # 0x3ffffffe000 +------------+--+ |     |            |     |    |            |
+        #               |            |  | |     |            |     |    |            |
+        #               |            |  | |     |            |     |    |            |
+        #               |            |  | |     +------------+     |    +------------+
+        #               |            |  | |     |            |<----|----|            |
+        #               |            |  | +---->|            |<----+----|            |
+        #               |            |  |       |            |<---------| one to one |
+        #               |            |  |       |    DRAM    |<---------| identical  |
+        #               |            |  +------>|            |<---------| mapping    |
+        #               |            |          |            |<---------|            |
+        #               |            |          |            |<---------|            |
+        #               |            |          +------------+          +------------+
+        #               |            |          |            |          |            |
+        #               |            |          |            |          |            |
+        #               |            |          |            |          |            |
+        #               |            |          |            |          |            |
+        #               |            |          |            |          |            |
+        #               |            |          |            |          |            |
+        #               +------------+          +------------+          +------------+
+        #
+        #               user page table         physical memory         kernel page table
+        #
+        #
         # code to switch between user and kernel space.
         #
         # this code is mapped at the same virtual address
         # (TRAMPOLINE) in user and kernel space so that
         # it continues to work when it switches page tables.
-	#
-	# kernel.ld causes this to be aligned
+        #
+        # kernel.ld causes this to be aligned
         # to a page boundary.
         #
-	.section trampsec
+.section trampsec
 .globl trampoline
 trampoline:
 .align 4
 .globl uservec
 uservec:    
-	#
+        #
         # trap.c sets stvec to point here, so
         # traps from user space start here,
         # in supervisor mode, but with a
         # user page table.
         #
-        # sscratch points to where the process's p->trapframe is
-        # mapped into user space, at TRAPFRAME.
-        #
-        
-	# swap a0 and sscratch
-        # so that a0 is TRAPFRAME
-        csrrw a0, sscratch, a0
+
+        # save user a0 in sscratch and
+        # load TRAPFRAME into a0
+        csrw sscratch, a0
+        li a0, TRAPFRAME
 
         # save the user registers in TRAPFRAME
         sd ra, 40(a0)
@@ -60,7 +86,7 @@ uservec:
         sd t5, 272(a0)
         sd t6, 280(a0)
 
-	# save the user a0 in p->trapframe->a0
+        # save the user a0 in p->trapframe->a0
         csrr t0, sscratch
         sd t0, 112(a0)
 
@@ -86,20 +112,16 @@ uservec:
 
 .globl userret
 userret:
-        # userret(TRAPFRAME, pagetable)
+        # userret(pagetable)
         # switch from kernel to user.
         # usertrapret() calls here.
-        # a0: TRAPFRAME, in user page table.
-        # a1: user page table, for satp.
+        # a0: user page table, for satp.
 
         # switch to the user page table.
-        csrw satp, a1
+        csrw satp, a0
         sfence.vma zero, zero
 
-        # put the saved user a0 in sscratch, so we
-        # can swap it with our a0 (TRAPFRAME) in the last step.
-        ld t0, 112(a0)
-        csrw sscratch, t0
+        li a0, TRAPFRAME
 
         # restore all but a0 from TRAPFRAME
         ld ra, 40(a0)
@@ -133,9 +155,9 @@ userret:
         ld t5, 272(a0)
         ld t6, 280(a0)
 
-	# restore user a0, and save TRAPFRAME in sscratch
-        csrrw a0, sscratch, a0
-        
+        # restore user a0
+        ld a0, 112(a0)
+
         # return to user mode and user pc.
         # usertrapret() set up sstatus and sepc.
         sret

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -125,7 +125,7 @@ usertrapret(void)
   // switches to the user page table, restores user registers,
   // and switches to user mode with sret.
   uint64 fn = TRAMPOLINE + (userret - trampoline);
-  ((void (*)(uint64,uint64))fn)(TRAPFRAME, satp);
+  ((void (*)(uint64))fn)(satp);
 }
 
 // interrupts and exceptions from kernel code go here via kernelvec,


### PR DESCRIPTION
TRAPFRAME is a fixed virtual address in the user page table,
we can use it directly.