### PR TITLE
Use NAPOT PMP to cover the entire physical address space

### DIFF
--- a/kernel/start.c
+++ b/kernel/start.c
@@ -40,8 +40,8 @@ start()
 
   // configure Physical Memory Protection to give supervisor mode
   // access to all of physical memory.
-  w_pmpaddr0(0x3fffffffffffffull);
-  w_pmpcfg0(0xf);
+  w_pmpaddr0(0x1fffffffffffffull);
+  w_pmpcfg0(0x1f);
 
   // ask for clock interrupts.
   timerinit();


### PR DESCRIPTION
The current PMP setting uses TOR regions, which does not cover the end of the
memory (spec: If PMP entry 0’s A field is set to TOR, zero is used for the lower
bound, and so it matches any address y < pmpaddr0).

Proposed new NAPOT PMP covers every byte of physical memory in the 56-bit
physical address space.

Quote from Andrew: you need to use a NAPOT PMP if you want to grant permissions
to the entire address space.

Relevant discussions:
* https://github.com/riscv/riscv-isa-manual/issues/138
* https://groups.google.com/a/groups.riscv.org/g/sw-dev/c/pn9ZCf0O65c/m/tnLTjg74CgAJ