### PR TITLE
Added missing va_end().

### DIFF
--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -109,6 +109,7 @@ printf(char *fmt, ...)
       break;
     }
   }
+  va_end(ap);
 
   if(locking)
     release(&pr.lock);


### PR DESCRIPTION
The `printf()` implementation lacks a `va_end(ap)` call before it returns, as `va_start(ap)` was used. `va_end` usually does nothing on most platforms, but [not including it is undefined behaviour in C](https://en.cppreference.com/w/c/variadic/va_end) and is thus unsafe.
