### PR TITLE
enable reading memory using gdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
-CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb
+CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb -gdwarf-2
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
 CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax


### PR DESCRIPTION
Need to enable this option in order to read variables during debugging using gdb.

Otherwise you will get a `Corrupted DWARF expression` when printing variable values.