### PR TITLE
Makefile: enable `-Wno-error=infinite-recursion` only in GCC 11 or higher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,18 @@ LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
-CFLAGS = -Wall -Werror -Wno-error=infinite-recursion -O -fno-omit-frame-pointer -ggdb
+CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
 CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax
 CFLAGS += -I.
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 
+# Enable flag -Wno-error=infinite-recursion when available
+GCC_VERSION = $(shell $(CC) -dumpversion | cut -d '.' -f1)
+ifeq ($(shell echo $(GCC_VERSION) / 11 2>/dev/null | bc | grep -e '^0'), )
+CFLAGS += -Wno-error=infinite-recursion
+endif
 # Disable PIE when possible (for Ubuntu 16.10 toolchain)
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)
 CFLAGS += -fno-pie -no-pie


### PR DESCRIPTION
According to [issue #130 ](https://github.com/mit-pdos/xv6-riscv/issues/130),  flag `-Wno-error=infinite-recursion`  will break compilation for all gcc versions prior to 11.
This PR is to fix it by making it available only in GCC 11 or higher.
I've tested it on Debian and it works fine.