### PR TITLE
atoi() modified to work with positive and negative numbers

### DIFF
--- a/user/ulib.c
+++ b/user/ulib.c
@@ -99,10 +99,18 @@ int
 atoi(const char *s)
 {
   int n;
+  char sign = '+';
 
+  if (*s == '-' || *s == '+'){
+    sign = *s++;
+  } 
   n = 0;
   while('0' <= *s && *s <= '9')
     n = n*10 + *s++ - '0';
+
+  if (sign == '-'){
+    n = n*(-1);
+  }
   return n;
 }
 


### PR DESCRIPTION
To whom it may concern,
my name is Heber Damián Alturria and i have noticed that atoi() only return 0 when we pass as input a string that represent a negative number such as "-1" or if it have a positive sign such as "+1". 
To solve the aforementioned situation, i have modified the implementation of atoi() to permit the use of positive and negative signs, resulting in results as interesting as: 

- atoi("204") is going to return the number 204.
- atoi("-21") is going to return the number -21.
- atoi("0") is going to return the number 0.
- atoi("+123") is going to return the number 123.
- atoi("+00000001") is going to return the number 1.
- atoi("-000000012") is going to return the number -12.

As you can appreciate, the operation of the atoi() that I have modified is similar to the atoi() provided by the C library called stdlib.h. 

thank you very much for reading and I hope you will consider adding the modification I have provided to the atoi(). 

best regards.