### PR TITLE
Remove all files created during testing

### DIFF
--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1277,7 +1277,7 @@ createdelete(char *s)
 
   for(i = 0; i < N; i++){
     for(pi = 0; pi < NCHILD; pi++){
-      name[0] = 'p' + i;
+      name[0] = 'p' + pi;
       name[1] = '0' + i;
       unlink(name);
     }


### PR DESCRIPTION
Remove the following files to restore the state of the filesystem,
so subsequent tests don't fail unexpectedly by creating same filename.

```
q0             2 21 0
q?             2 22 0
q;             2 23 0
qC             2 24 0
q=             2 25 0
qA             2 26 0
q:             2 27 0
q<             2 28 0
q>             2 29 0
q@             2 30 0
qB             2 31 0
r0             2 32 0
r?             2 33 0
r;             2 34 0
rC             2 35 0
r=             2 36 0
rA             2 37 0
r:             2 38 0
r<             2 39 0
r>             2 40 0
r@             2 41 0
rB             2 42 0
s0             2 43 0
s?             2 44 0
s;             2 45 0
sC             2 46 0
s=             2 47 0
sA             2 48 0
s:             2 49 0
s<             2 50 0
s>             2 51 0
p?             2 52 0
p;             2 53 0
pC             2 54 0
p=             2 55 0
pA             2 56 0
p:             2 57 0
p<             2 58 0
p>             2 59 0
p@             2 60 0
pB             2 61 0
s@             2 62 0
sB             2 63 0
```