### PR TITLE
Report an error when `n` is not equal to `MAXFILE`

### DIFF
--- a/user/usertests.c
+++ b/user/usertests.c
@@ -606,7 +606,7 @@ writebig(char *s)
   for(;;){
     i = read(fd, buf, BSIZE);
     if(i == 0){
-      if(n == MAXFILE - 1){
+      if(n != MAXFILE){
         printf("%s: read only %d blocks from big", s, n);
         exit(1);
       }


### PR DESCRIPTION
The variable `n` represents the number of blocks that have been read.