### PR TITLE
Fix write redirection typo in sh.c

### DIFF
--- a/user/sh.c
+++ b/user/sh.c
@@ -134,7 +134,7 @@ runcmd(struct cmd *cmd)
 int
 getcmd(char *buf, int nbuf)
 {
-  write(2, "$ ", 2);
+  write(1, "$ ", 2);
   memset(buf, 0, nbuf);
   gets(buf, nbuf);
   if(buf[0] == 0) // EOF


### PR DESCRIPTION
In `sh.c` function `getcmd` (Line 135), we print the `$` sign as standard output rather than standard error.