### PR TITLE
fix(kernel/stat): include types before use

### DIFF
--- a/kernel/stat.h
+++ b/kernel/stat.h
@@ -1,6 +1,11 @@
-#define T_DIR     1   // Directory
-#define T_FILE    2   // File
-#define T_DEVICE  3   // Device
+#ifndef __KERNEL_STST__
+#define __KERNEL_STST__
+
+#include "types.h"
+
+#define T_DIR 1    // Directory
+#define T_FILE 2   // File
+#define T_DEVICE 3 // Device
 
 struct stat {
   int dev;     // File system's disk device
@@ -9,3 +14,5 @@ struct stat {
   short nlink; // Number of links to file
   uint64 size; // Size of file in bytes
 };
+
+#endif


### PR DESCRIPTION
Some foratter may change the order of include files.

We used to have to include "kernel/types.h" first, or compiler will complain "unknown type uint" if we try to include "kernel/stat.h".