### PR TITLE
printf fixed

### DIFF
--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -81,8 +81,10 @@ printf(char *fmt, ...)
       continue;
     }
     c = fmt[++i] & 0xff;
-    if(c == 0)
+    if(c == 0){
+      consputc('%');
       break;
+    }
     switch(c){
     case 'd':
       printint(va_arg(ap, int), 10, 1);


### PR DESCRIPTION
When printing "%", printf ignores this since pointer reaches the end of the string.