### PR TITLE
start() in ulib.c: exit(main());

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ OBJDUMP = $(TOOLPREFIX)objdump
 CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb -gdwarf-2
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
-CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax
+CFLAGS += -ffreestanding -fno-common -nostdlib
 CFLAGS += -I.
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -7,11 +7,10 @@
 // wrapper so that it's OK if main() does not call exit().
 //
 void
-_main()
+start()
 {
   extern int main();
-  main();
-  exit(0);
+  exit(main());
 }
 
 char*

--- a/user/user.ld
+++ b/user/user.ld
@@ -1,6 +1,4 @@
 OUTPUT_ARCH( "riscv" )
-ENTRY( _main )
-
 
 SECTIONS
 {


### PR DESCRIPTION
Change _main() function for start() in ulib.c.
user.ld doesn't need to set ENTRY() point.
start() now calls exit(main()); so user programs return main() value as exit code.