### PR TITLE
Update entry.S

### DIFF
--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -8,7 +8,9 @@ _entry:
         # set up a stack for C.
         # stack0 is declared in start.c,
         # with a 4096-byte stack per CPU.
-        # sp = stack0 + (hartid * 4096)
+        # Read the hardware thread ID ('mhartid') into register 'a1'.
+        # Increment the hardware thread ID by 1 to avoid a stack overlap issue
+        # sp = stack0 + ((hartid + 1) * 4096)
         la sp, stack0
         li a0, 1024*4
         csrr a1, mhartid


### PR DESCRIPTION
corrected the typo here

> 
>     # Read the hardware thread ID ('mhartid') into register 'a1'.
>     csrr a1, mhartid
> 
>     # Increment the hardware thread ID by 1 to avoid a stack overlap issue.
>     addi a1, a1, 1
> 
>     # Calculate the new stack pointer value:
>     # sp = stack0 + ((hartid + 1) * 4096)
>     mul a0, a0, a1
>     add sp, sp, a0