### PR TITLE
Put parentheses around macro argument.

### DIFF
--- a/kernel/uart.c
+++ b/kernel/uart.c
@@ -13,7 +13,7 @@
 // the UART control registers are memory-mapped
 // at address UART0. this macro returns the
 // address of one of the registers.
-#define Reg(reg) ((volatile unsigned char *)(UART0 + reg))
+#define Reg(reg) ((volatile unsigned char *)(UART0 + (reg)))
 
 // the UART control registers.
 // some have different meanings for


### PR DESCRIPTION
It might be too paranoid but makes it safe to deal with operators with lower priorities than '+', '<<' for example.