### PR TITLE
[Makefile] Add unoptimized build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
-CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb -gdwarf-2
+CFLAGS = -Wall -Werror -fno-omit-frame-pointer -ggdb -gdwarf-2
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
 CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax
@@ -161,13 +161,24 @@ QEMUOPTS += -global virtio-mmio.force-legacy=false
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
 
+qemu: CFLAGS += -O
 qemu: $K/kernel fs.img
+	$(QEMU) $(QEMUOPTS)
+
+qemu-noopt: CFLAGS += -O0
+qemu-noopt: $K/kernel fs.img
 	$(QEMU) $(QEMUOPTS)
 
 .gdbinit: .gdbinit.tmpl-riscv
 	sed "s/:1234/:$(GDBPORT)/" < $^ > $@
 
+qemu-gdb: CFLAGS += -O
 qemu-gdb: $K/kernel .gdbinit fs.img
+	@echo "*** Now run 'gdb' in another window." 1>&2
+	$(QEMU) $(QEMUOPTS) -S $(QEMUGDB)
+
+qemu-gdb-noopt: CFLAGS += -O0
+qemu-gdb-noopt: $K/kernel .gdbinit fs.img
 	@echo "*** Now run 'gdb' in another window." 1>&2
 	$(QEMU) $(QEMUOPTS) -S $(QEMUGDB)
 


### PR DESCRIPTION
Problem:
When debugging xv6, many variables could not be examined and would return the message "optimized out". For example, in the `readi` function of `kernel/fs.c` the variable `m` is optimized out at various points of the debugging process:

    Breakpoint 1, readi (ip=.., user_dst=.., dst=.., off=.., n=..) at kernel/fs.c:477
    477       if(off > ip->size || off + n < off)
    (gdb) n
    479       if(off + n > ip->size)
    (gdb) n
    482       for(tot=0; tot<n; tot+=m, off+=m, dst+=m){
    (gdb) p m
    $1 = <optimized out>
    (gdb)

Issue:
Both the `qemu` and `qemu-gdb` targets in the Makefile build the kernel using the `-O` general optimization option for gcc. This is appropriate for a non-debug run of xv6, but causes problems viewing the content of variables that have been optimized out.

Solution:
Two new build targets are added to the Makefile:

* qemu-noopt - Builds the xv6 kernel with optimization turned off
* qemu-gdb-noopt - Builds the xv6 kernel with optimization turned off
  and starts qemu as a gdb server.

This preserves the functionality of the original build targets while allowing the build of non-optimized kernels for debugging purposes.