### PR TITLE
Fix bug where long directory names might not be null-terminated

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -597,7 +597,7 @@ dirlink(struct inode *dp, char *name, uint inum)
       break;
   }
 
-  strncpy(de.name, name, DIRSIZ);
+  safestrcpy(de.name, name, DIRSIZ);
   de.inum = inum;
   if(writei(dp, 0, (uint64)&de, off, sizeof(de)) != sizeof(de))
     return -1;

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -151,7 +151,8 @@ main(int argc, char *argv[])
 
     bzero(&de, sizeof(de));
     de.inum = xshort(inum);
-    strncpy(de.name, shortname, DIRSIZ);
+    strncpy(de.name, shortname, DIRSIZ - 1);
+    de.name[DIRSIZ - 1] = '\0';
     iappend(rootino, &de, sizeof(de));
 
     while((cc = read(fd, buf, sizeof(buf))) > 0)


### PR DESCRIPTION
On some versions of gcc, compiling `mkfs.c` fails because of the `stringop-truncation` warning triggered by this line: https://github.com/mit-pdos/xv6-riscv/blob/riscv/mkfs/mkfs.c#L154.

See [gcc docs](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-truncation) for an explanation of this warning. In short, if `shortname` is too long, the string in the direntry buffer will not be null-terminated.

We fixed this by copying only the first `DIRSIZE - 1` bytes and setting the last byte to null.
A similar case was found in `kernel/fs.c` where we can instead use `safestrcpy`.

Please let me know if there is anything that we have overlooked.

