### PR TITLE
Fix the error reporting problem of runcmd function during compilation…

### DIFF
--- a/user/sh.c
+++ b/user/sh.c
@@ -56,6 +56,7 @@ void runcmd(struct cmd*) __attribute__((noreturn));
 
 // Execute cmd.  Never returns.
 void
+__attribute__((noreturn))
 runcmd(struct cmd *cmd)
 {
   int p[2];


### PR DESCRIPTION
When I enter make qemu to compile, an error in the runcmd function will be displayed, as shown in the following figure:
![1](https://github.com/mit-pdos/xv6-riscv/assets/103946808/0df45763-60aa-46f8-b42d-eb99706b85a3)
My solution: add __attribute__((noreturn)) above runcmd in user/sh.c.
Increased compilation effect, successfully entered the terminal after compilation
![2](https://github.com/mit-pdos/xv6-riscv/assets/103946808/bee73837-a106-4833-82fa-6de88931ef8d)
