### PR TITLE
fix comment in entry.S

### DIFF
--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -8,7 +8,7 @@ _entry:
         # set up a stack for C.
         # stack0 is declared in start.c,
         # with a 4096-byte stack per CPU.
-        # sp = stack0 + (hartid * 4096)
+        # sp = stack0 + ((hartid + 1) * 4096)
         la sp, stack0
         li a0, 1024*4
         csrr a1, mhartid


### PR DESCRIPTION
`sp` initially refers to the bottom of the stack allocated to each CPU.