### PR TITLE
feature/qemu-config -  Add config parameter to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 K=kernel
 U=user
 
+# 128M is the default for xv6 - Warning no trailing space after the number
+RAM=128
+# 3 is the default for xv6
+CPUCOUNT=3
+
+
+
 OBJS = \
   $K/entry.o \
   $K/start.o \
@@ -59,6 +66,8 @@ OBJDUMP = $(TOOLPREFIX)objdump
 CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb -gdwarf-2
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
+CFLAGS += -DMAXMEM=$(RAM)
+CFLAGS += -DNCPU=$(CPUCOUNT)
 # CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax
 CFLAGS += -fno-common -nostdlib
 CFLAGS += -fno-builtin-strncpy -fno-builtin-strncmp -fno-builtin-strlen -fno-builtin-memset
@@ -160,10 +169,10 @@ QEMUGDB = $(shell if $(QEMU) -help | grep -q '^-gdb'; \
 	then echo "-gdb tcp::$(GDBPORT)"; \
 	else echo "-s -p $(GDBPORT)"; fi)
 ifndef CPUS
-CPUS := 3
+CPUS := $(CPUCOUNT)
 endif
 
-QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic
+QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m $(RAM)M -smp $(CPUS) -nographic
 QEMUOPTS += -global virtio-mmio.force-legacy=false
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0

--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -9,7 +9,7 @@ _entry:
         # set up a stack for C.
         # stack0 is declared in start.c,
         # with a CPUSTACKSIZE-kilobytes stack per CPU as definied in param.h.
-        # sp = stack0 + (hartid * CPUSTACKSIZE)
+        # sp = stack0 + ((hartid + 1) * CPUSTACKSIZE)
         la sp, stack0
         li a0, 1024 * CPUSTACKSIZE
         csrr a1, mhartid

--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -1,3 +1,4 @@
+#include "param.h"
         # qemu -kernel loads the kernel at 0x80000000
         # and causes each hart (i.e. CPU) to jump there.
         # kernel.ld causes the following code to
@@ -7,10 +8,10 @@
 _entry:
         # set up a stack for C.
         # stack0 is declared in start.c,
-        # with a 4096-byte stack per CPU.
-        # sp = stack0 + (hartid * 4096)
+        # with a CPUSTACKSIZE-kilobytes stack per CPU as definied in param.h.
+        # sp = stack0 + (hartid * CPUSTACKSIZE)
         la sp, stack0
-        li a0, 1024*4
+        li a0, 1024 * CPUSTACKSIZE
         csrr a1, mhartid
         addi a1, a1, 1
         mul a0, a0, a1

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -28,6 +28,8 @@ kinit()
 {
   initlock(&kmem.lock, "kmem");
   freerange(end, (void*)PHYSTOP);
+  // Output the start and end of Memory to see if change to RAM parameter in Makefile has an effect
+  printf("kinit: Memory start addr: %p,  Memory end addr:%p\n",end, (void*)PHYSTOP);
 }
 
 void

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -37,7 +37,7 @@
 // for use by the kernel and user pages
 // from physical address 0x80000000 to PHYSTOP.
 #define KERNBASE 0x80000000L
-#define PHYSTOP (KERNBASE + 128*1024*1024)
+#define PHYSTOP (KERNBASE + MAXMEM*1024*1024)
 
 // map the trampoline page to the highest address,
 // in both user and kernel space.

--- a/kernel/param.h
+++ b/kernel/param.h
@@ -1,5 +1,5 @@
+#define CPUSTACKSIZE  4 // Stacksize in KB per CPU - Currently leave on 4 KB this is xv6 default
 #define NPROC        64  // maximum number of processes
-#define NCPU          8  // maximum number of CPUs
 #define NOFILE       16  // open files per process
 #define NFILE       100  // open files per system
 #define NINODE       50  // maximum number of active i-nodes
@@ -13,3 +13,6 @@
 #define MAXPATH      128   // maximum file path name
 #define USERSTACK    1     // user stack pages
 
+// Defined in Makefile, so it is dynamic based on the config for qemu
+//#define NCPU          8  // maximum number of CPUs
+//#define MAXMEM       128   // max Memory in megabyte

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -8,7 +8,7 @@ void main();
 void timerinit();
 
 // entry.S needs one stack per CPU.
-__attribute__ ((aligned (16))) char stack0[4096 * NCPU];
+__attribute__ ((aligned (16))) char stack0[1024 * CPUSTACKSIZE * NCPU];
 
 // entry.S jumps here in machine mode on stack0.
 void


### PR DESCRIPTION
Add Config parameter RAM and CPUCOUNT to the head of Makefile to call qemu with the parameter's defined in the Top of the file. The Parameter will be used in compiler flags to define NCPU and MAXMEM parameters. This  will be used in the code to make sure the changes are reflected without any source code changes.

Added CPUSTACKSIZE to kernel/param.h to allow some experiments with the  Stacksize per CPU in future.

Added some output in kinit function to see if changes to RAM are reflected. Remark: You have to "make clean && make qemu" after changes to the RAM Variable.
