### PR TITLE
let printf understands %c

### DIFF
--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -108,6 +108,8 @@ printf(char *fmt, ...)
       i += 2;
     } else if(c0 == 'p'){
       printptr(va_arg(ap, uint64));
+    } else if(c0 == 'c'){
+      putc(fd, va_arg(ap, int));
     } else if(c0 == 's'){
       if((s = va_arg(ap, char*)) == 0)
         s = "(null)";

--- a/user/printf.c
+++ b/user/printf.c
@@ -47,7 +47,7 @@ printptr(int fd, uint64 x) {
     putc(fd, digits[x >> (sizeof(uint64) * 8 - 4)]);
 }
 
-// Print to the given fd. Only understands %d, %x, %p, %s.
+// Print to the given fd. Only understands %d, %x, %p, %c, %s.
 void
 vprintf(int fd, const char *fmt, va_list ap)
 {
@@ -93,6 +93,8 @@ vprintf(int fd, const char *fmt, va_list ap)
         i += 2;
       } else if(c0 == 'p'){
         printptr(fd, va_arg(ap, uint64));
+      } else if(c0 == 'c'){
+        putc(fd, va_arg(ap, int));
       } else if(c0 == 's'){
         if((s = va_arg(ap, char*)) == 0)
           s = "(null)";


### PR DESCRIPTION
We utilize xv6 as part of our teaching materials. Recently, we designed an exercise in which students use pipes to send bytes and display characters via printf. During this, we observed that the current printf implementation in xv6 does not support the `%c` specifier to print single characters.

This update involves only two additional lines and allows for `%c` usage, which is frequently needed for character display. We believe this adjustment would enhance the learning experience and minimize confusion among students.

It looks like forgot to implement when rewriting `printf` in dd2574bc1097a912e799340172b8b6ef42ac5ceb. In the commented parts, parsing `%c` still exists.

resolves #283