### PR TITLE
fix kernel.ld so that _entry will appear in the right place

### DIFF
--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -10,6 +10,7 @@ SECTIONS
   . = 0x80000000;
 
   .text : {
+    kernel/entry.o(_entry)
     *(.text .text.*)
     . = ALIGN(0x1000);
     _trampoline = .;


### PR DESCRIPTION
#288 fix the problem of kernel.ld