### PR TITLE
refactor: clearer user.h

### DIFF
--- a/user/user.h
+++ b/user/user.h
@@ -29,14 +29,16 @@ char* strcpy(char*, const char*);
 void *memmove(void*, const void*, int);
 char* strchr(const char*, char c);
 int strcmp(const char*, const char*);
-void fprintf(int, const char*, ...) __attribute__ ((format (printf, 2, 3)));
-void printf(const char*, ...) __attribute__ ((format (printf, 1, 2)));
 char* gets(char*, int max);
 uint strlen(const char*);
 void* memset(void*, int, uint);
 int atoi(const char*);
 int memcmp(const void *, const void *, uint);
 void *memcpy(void *, const void *, uint);
+
+// printf.c
+void fprintf(int, const char*, ...) __attribute__ ((format (printf, 2, 3)));
+void printf(const char*, ...) __attribute__ ((format (printf, 1, 2)));
 
 // umalloc.c
 void* malloc(uint);


### PR DESCRIPTION
`printf` and `fprintf` were created in a seperate file `printf.c` (since 28d9ef04ddaa4cf32f3c63c976afdc535a36db98).

This PR reorganizes `user.h` and makes its corresponding implementation file clearer.