### PR TITLE
remove ramdisk functions from defs.h

### DIFF
--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -54,11 +54,6 @@ void            stati(struct inode*, struct stat*);
 int             writei(struct inode*, int, uint64, uint, uint);
 void            itrunc(struct inode*);
 
-// ramdisk.c
-void            ramdiskinit(void);
-void            ramdiskintr(void);
-void            ramdiskrw(struct buf*);
-
 // kalloc.c
 void*           kalloc(void);
 void            kfree(void *);


### PR DESCRIPTION
As ramdisk support is removed from the project, these declarations useless.