### PR TITLE
Fixed buffer overflow in printint

### DIFF
--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -28,7 +28,7 @@ static char digits[] = "0123456789abcdef";
 static void
 printint(long long xx, int base, int sign)
 {
-  char buf[16];
+  char buf[20];
   int i;
   unsigned long long x;
 

--- a/user/printf.c
+++ b/user/printf.c
@@ -13,9 +13,9 @@ putc(int fd, char c)
 }
 
 static void
-printint(int fd, int xx, int base, int sgn)
+printint(int fd, long long xx, int base, int sgn)
 {
-  char buf[16];
+  char buf[20];
   int i, neg;
   uint x;
 


### PR DESCRIPTION
Hi

There is a buffer overflow in `printint` function which can be triggered if numbers with more than 16 digits are written to the terminal. Numbers 18446744073709551615 and -9223372036854775808 both have 20 digits for instance. To this extent, I increased the buffer size to 20 characters which can fit base 10 of all 64 bit numbers (negative or positive).

I was also curious if this bug exists in x86 version of xv6. But apparently, the [`printint`](https://github.com/mit-pdos/xv6-public/blob/eeb7b415dbcb12cc362d0783e41c3d1f44066b17/printf.c#L11-L36) function used to accept an `int` instead of `long long` which was only 32 bits!