### PR TITLE
mkfs: Ignore strinop-truncation warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ $U/_forktest: $U/forktest.o $(ULIB)
 	$(OBJDUMP) -S $U/_forktest > $U/forktest.asm
 
 mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
-	gcc -Werror -Wall -I. -o mkfs/mkfs mkfs/mkfs.c
+	gcc -Werror -Wall -Wno-stringop-truncation -I. -o mkfs/mkfs mkfs/mkfs.c
 
 # Prevent deletion of intermediate files, e.g. cat.o, after first build, so
 # that disk image changes after first build are persistent until clean.  More


### PR DESCRIPTION
mkfs uses the builtin `strncpy`, rather than kernel/strings.c, which, as of GCC-8, warns when `n` is the same size as the destination buffer, as it may not be able to add a NULL byte.

This is the desired behavior for xv6 directory entry names (which only require a NULL byte if they are shorter than DIRSIZ), but odd for normal uses of strncpy. So just ignore the warning to appease newer GCCs.