### PR TITLE
Add support for segments that are not page aligned

### DIFF
--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -122,7 +122,7 @@ walkaddr(pagetable_t pagetable, uint64 va)
   if((*pte & PTE_U) == 0)
     return 0;
   pa = PTE2PA(*pte);
-  return pa;
+  return pa + (va & 0xfff);
 }
 
 // add a mapping to the kernel page table.


### PR DESCRIPTION
Certain compiler toolchains produce executable files that are not aligned to page boundaries, making the kernel unable to load executables from those toolchains.

Using this patch the operating system supports building the entire operating system with clang and the llvm toolchain.