### PR TITLE
modified input parameter of rwsbrk

### DIFF
--- a/user/usertests.c
+++ b/user/usertests.c
@@ -244,7 +244,7 @@ copyinstr3(char *s)
 // See if the kernel refuses to read/write user memory that the
 // application doesn't have anymore, because it returned it.
 void
-rwsbrk()
+rwsbrk(char *s)
 {
   int fd, n;
   


### PR DESCRIPTION
In riscv64-unknown-elf-gcc (GCC) 15.1.0, pass void (*)(void) to struct test caused a compile error, modified input of rwsbrk() from `void` to `char *s`.