### PR TITLE
add riscv64-elf as TOOLPREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ OBJS = \
 ifndef TOOLPREFIX
 TOOLPREFIX := $(shell if riscv64-unknown-elf-objdump -i 2>&1 | grep 'elf64-big' >/dev/null 2>&1; \
 	then echo 'riscv64-unknown-elf-'; \
+	elif riscv64-elf-objdump -i 2>&1 | grep 'elf64-big' >/dev/null 2>&1; \
+	then echo 'riscv64-elf-'; \
 	elif riscv64-linux-gnu-objdump -i 2>&1 | grep 'elf64-big' >/dev/null 2>&1; \
 	then echo 'riscv64-linux-gnu-'; \
 	elif riscv64-unknown-linux-gnu-objdump -i 2>&1 | grep 'elf64-big' >/dev/null 2>&1; \


### PR DESCRIPTION
Adding riscv64-elf as a valid TOOLPREFIX

Solving the Issue: https://github.com/mit-pdos/xv6-riscv/issues/356