### PR TITLE
kernel/uart: use the existing LSR_RX_READY macro for readability

### DIFF
--- a/kernel/uart.c
+++ b/kernel/uart.c
@@ -161,7 +161,7 @@ uartstart()
 int
 uartgetc(void)
 {
-  if(ReadReg(LSR) & 0x01){
+  if(ReadReg(LSR) & LSR_RX_READY){
     // input data is ready.
     return ReadReg(RHR);
   } else {


### PR DESCRIPTION
`kernel/uart.c` defines `LSR_RX_READY` but never actually uses it. `uartgetc()` instead tests `ReadReg(LSR) & 0x01`, leaving a “magic
number” in the hot path.

This PR replaces that literal with the symbolic constant. Behaviour is unchanged; it’s a pure style / maintainability fix.