### PR TITLE
Enable -ffreestanding option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ OBJDUMP = $(TOOLPREFIX)objdump
 CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb -gdwarf-2
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
-# CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax
+# CFLAGS += -fno-common -nostdlib -mno-relax
+CFLAGS += -ffreestanding
 CFLAGS += -fno-common -nostdlib
 CFLAGS += -fno-builtin-strncpy -fno-builtin-strncmp -fno-builtin-strlen -fno-builtin-memset
 CFLAGS += -fno-builtin-memmove -fno-builtin-memcmp -fno-builtin-log -fno-builtin-bzero


### PR DESCRIPTION
GCC can emit 'call memset', 'call memcpy', and 'call memmove' anywhere for aggregate copying and initialization. For example:

    struct foo {
      int bar[100];
    };
    
    struct foo get_foo(void)
    {
      struct foo foo = { 0 }; // => addi    a5,s0,-416
                              //    li      a4,400
                              //    mv      a2,a4
                              //    li      a1,0
                              //    mv      a0,a5
                              //    call    memset
                              //    ^^^^^^^^^^^^^^
    
      return foo;             // => ld      a5,-424(s0)
                              //    mv      a3,a5
                              //    addi    a5,s0,-416
                              //    li      a4,400
                              //    mv      a2,a4
                              //    mv      a1,a5
                              //    mv      a0,a3
                              //    call    memcpy
                              //    ^^^^^^^^^^^^^^
    }

Things get tricky when we need to implement memset(). If GCC emits 'call memset' instruction inside memset() function, memset() will accidentally become an infinite recursive function, eventually causing a stack overflow.

Consider compiling xv6's memset() with '-O2' optimization:

    void*
    memset(void *dst, int c, uint n)
    {
      char *cdst = (char *) dst;
      int i;
      for(i = 0; i < n; i++){
        cdst[i] = c;
      }
      return dst;
    }

    $ riscv64-unknown-elf-gcc -O2 -fno-builtin-memset -S -o \
      xv6-memset.S xv6-memset.c

        .file   "xv6-memset.c"
        .option nopic
        .attribute arch, "rv64i2p0_m2p0_a2p0_f2p0_d2p0_c2p0"
        .attribute unaligned_access, 0
        .attribute stack_align, 16
        .text
        .align  1
        .globl  memset
        .type   memset, @function
    memset:
    ^^^^^^
        addi    sp,sp,-16
        sd      s0,0(sp)
        sd      ra,8(sp)
        mv      s0,a0
        beq     a2,zero,.L4
        slli    a2,a2,32
        srli    a2,a2,32
        andi    a1,a1,0xff
        call    memset
        ^^^^^^^^^^^^^^
    .L4:
        ld      ra,8(sp)
        mv      a0,s0
        ld      s0,0(sp)
        addi    sp,sp,16
        jr      ra
        .size   memset, .-memset
        .ident  "GCC: () 10.2.0"

Enable the -ffreestanding, -fno-hosted or -fno-builtin option to avoid this.

Additionally, -fno-builtin-memset is used to tell GCC not to use __builtin_memset(), which is usually related to inline copy loop optimization. For example:

    char s[100];

    void
    foo(void)
    {
      memset(s, 0, sizeof(s));
    }

    $ riscv64-unknown-elf-gcc -O -S -o foo.S foo.c

    foo:
        lui     a5,%hi(.LANCHOR0)
        addi    a5,a5,%lo(.LANCHOR0)
        # inline copy loop
        # vvvvvvvvvvvvvvvvv
        sd      zero,0(a5)
        sd      zero,8(a5)
        sd      zero,16(a5)
        sd      zero,24(a5)
        sd      zero,32(a5)
        sd      zero,40(a5)
        sd      zero,48(a5)
        sd      zero,56(a5)
        sd      zero,64(a5)
        sd      zero,72(a5)
        sd      zero,80(a5)
        sd      zero,88(a5)
        sw      zero,96(a5)
        # ^^^^^^^^^^^^^^^^^
        ret
        .size   foo, .-foo
        .globl  s
        .bss
        .align  3
        .set    .LANCHOR0,. + 0
        .type   s, @object
        .size   s, 100
    s:
        .zero   100
        .ident  "GCC: () 10.2.0"

    $ riscv64-unknown-elf-gcc -O -fno-builtin-memset -S -o foo.S foo.c
                                 ^^^^^^^^^^^^^^^^^^^
    foo:
        addi    sp,sp,-16
        sd      ra,8(sp)
        li      a2,100
        li      a1,0
        lui     a0,%hi(.LANCHOR0)
        addi    a0,a0,%lo(.LANCHOR0)
        # no inline copy loop
        call    memset
        ^^^^^^^^^^^^^^
        ld      ra,8(sp)
        addi    sp,sp,16
        jr      ra
        .size   foo, .-foo
        .globl  s
        .bss
        .align  3
        .set    .LANCHOR0,. + 0
        .type   s, @object
        .size   s, 100
    s:
        .zero   100
        .ident  "GCC: () 10.2.0"

Reference:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103579
https://github.com/llvm/llvm-project/issues/63232#issuecomment-2940875834