### PR TITLE
Avoid sleeping on uart_tx_r if panicking

### DIFF
--- a/kernel/uart.c
+++ b/kernel/uart.c
@@ -94,7 +94,7 @@ uartputc(int c)
     for(;;)
       ;
   }
-  while(uart_tx_w == uart_tx_r + UART_TX_BUF_SIZE){
+  while(panicking == 0 && uart_tx_w == uart_tx_r + UART_TX_BUF_SIZE){
     // buffer is full.
     // wait for uartstart() to open up space in the buffer.
     sleep(&uart_tx_r, &uart_tx_lock);


### PR DESCRIPTION
In `uartputc`, the `sleep()` call will release `uart_tx_lock`. However as of commit 9c2419f, `uart_tx_lock` is not acquired during a kernel panic, so `sleep()` should be avoided while panicking.