### PR TITLE
[Makefile] optimze FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ $U/usys.S : $U/usys.pl
 $U/usys.o : $U/usys.S
 	$(CC) $(CFLAGS) -c -o $U/usys.o $U/usys.S
 
-$U/_forktest: $U/forktest.o $(ULIB)
+$U/_forktest: $U/forktest.o $U/forktest.o $U/ulib.o $U/usys.o
 	# forktest has less library code linked in - needs to be small
 	# in order to be able to max out the proc table.
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/ulib.o $U/usys.o

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ $U/usys.S : $U/usys.pl
 $U/usys.o : $U/usys.S
 	$(CC) $(CFLAGS) -c -o $U/usys.o $U/usys.S
 
-$U/_forktest: $U/forktest.o $U/forktest.o $U/ulib.o $U/usys.o
+$U/_forktest: $U/forktest.o $U/ulib.o $U/usys.o
 	# forktest has less library code linked in - needs to be small
 	# in order to be able to max out the proc table.
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/ulib.o $U/usys.o

--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,8 @@ CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb -gdwarf-2
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
 CFLAGS += -ffreestanding
-CFLAGS += -fno-common -nostdlib
-CFLAGS += -fno-builtin-strncpy -fno-builtin-strncmp -fno-builtin-strlen -fno-builtin-memset
-CFLAGS += -fno-builtin-memmove -fno-builtin-memcmp -fno-builtin-log -fno-builtin-bzero
-CFLAGS += -fno-builtin-strchr -fno-builtin-exit -fno-builtin-malloc -fno-builtin-putc
-CFLAGS += -fno-builtin-free
-CFLAGS += -fno-builtin-memcpy -Wno-main
-CFLAGS += -fno-builtin-printf -fno-builtin-fprintf -fno-builtin-vprintf
+CFLAGS += -fno-common
+CFLAGS += -fno-builtin -Wno-main
 CFLAGS += -I.
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 
@@ -81,7 +76,7 @@ ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
 endif
 
-LDFLAGS = -z max-page-size=4096
+LDFLAGS = -z max-page-size=4096 -nostdlib
 
 $K/kernel: $(OBJS) $K/kernel.ld
 	$(LD) $(LDFLAGS) -T $K/kernel.ld -o $K/kernel $(OBJS) 

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -9,7 +9,7 @@
 //   control-p -- print process list
 //
 
-#include <stdarg.h>
+#include "printf.h"
 
 #include "types.h"
 #include "param.h"

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -2,7 +2,7 @@
 // formatted console output -- printf, panic.
 //
 
-#include <stdarg.h>
+#include "printf.h"
 
 #include "types.h"
 #include "param.h"

--- a/kernel/printf.h
+++ b/kernel/printf.h
@@ -1,0 +1,5 @@
+typedef __builtin_va_list va_list;
+
+#define va_arg(ap, type) __builtin_va_arg(ap, type)
+#define va_start(ap, param) __builtin_va_start(ap, param)
+#define va_end(ap) __builtin_va_end(ap)

--- a/user/printf.c
+++ b/user/printf.c
@@ -2,7 +2,7 @@
 #include "kernel/stat.h"
 #include "user/user.h"
 
-#include <stdarg.h>
+#include "kernel/printf.h"
 
 static char digits[] = "0123456789ABCDEF";
 


### PR DESCRIPTION
replace these `-fno-builtin-function` **CFLAGS** by one `-fno-builtin`

move `-nostdlib` to **LDFLAGS** cause it only works when compiler do the linking stage

https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/C-Dialect-Options.html#index-fno-builtin

https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Link-Options.html#index-nostdlib

fully remove **stdlib depedency** by define the builtin macro in `printf.h`

`$U/_forktest` depend on `$U/forktest.o $U/ulib.o $U/usys.o` not all `$(ULIB)`