### PR TITLE
fix string termination in mkfs

### DIFF
--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -147,13 +147,14 @@ main(int argc, char *argv[])
     if(shortname[0] == '_')
       shortname += 1;
 
-    assert(strlen(shortname) <= DIRSIZ);
+    assert(strlen(shortname) < DIRSIZ);
     
     inum = ialloc(T_FILE);
 
     bzero(&de, sizeof(de));
     de.inum = xshort(inum);
     strncpy(de.name, shortname, DIRSIZ);
+    de.name[DIRSIZ - 1] = '\0';
     iappend(rootino, &de, sizeof(de));
 
     while((cc = read(fd, buf, sizeof(buf))) > 0)


### PR DESCRIPTION
- fixes GCC 11 stringop-truncation warning:
```
gcc -DSOL_UTIL -DLAB_UTIL -Werror -Wall -I. -o mkfs/mkfs mkfs/mkfs.c
mkfs/mkfs.c: In function ‘main’:
mkfs/mkfs.c:156:5: error: ‘__builtin_strncpy’ specified bound 14 equals destination size [-Werror=stringop-truncation]
  156 |     strncpy(de.name, shortname, DIRSIZ);
      |     ^
cc1: all warnings being treated as errors
```

- fix strlen check to reserve size for terminating null byte
- explicitly null-terminate `de.name`