### PR TITLE
update the comment in trampoline.S

### DIFF
--- a/kernel/trampoline.S
+++ b/kernel/trampoline.S
@@ -145,5 +145,5 @@ userret:
         ld a0, 112(a0)
         
         # return to user mode and user pc.
-        # usertrapret() set up sstatus and sepc.
+        # prepare_return() set up sstatus and sepc.
         sret


### PR DESCRIPTION
usertrapret no longer exists after commit c161fb79 and was refactored to prepare_return.