### PR TITLE
Atomically enabling and disabling interrupts

### DIFF
--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -61,6 +61,32 @@ w_sstatus(uint64 x)
   asm volatile("csrw sstatus, %0" : : "r" (x));
 }
 
+static inline void
+s_sstatus(uint64 x)
+{
+  __asm__ __volatile__("csrs sstatus, %0" ::
+                       "rK" (x) :
+                       "memory");
+}
+
+static inline void
+c_sstatus(uint64 x)
+{
+  __asm__ __volatile__("csrc sstatus, %0" ::
+                       "rK" (x) :
+                       "memory");
+}
+
+static inline uint64
+rc_sstatus(uint64 x)
+{
+  __asm__ __volatile__("csrrc %0, sstatus, %1" :
+                       "=r" (x) :
+                       "rK" (x) :
+                       "memory");
+  return x;
+}
+
 // Supervisor Interrupt Pending
 static inline uint64
 r_sip()
@@ -286,14 +312,14 @@ r_time()
 static inline void
 intr_on()
 {
-  w_sstatus(r_sstatus() | SSTATUS_SIE);
+  s_sstatus(SSTATUS_SIE);
 }
 
 // disable device interrupts
 static inline void
 intr_off()
 {
-  w_sstatus(r_sstatus() & ~SSTATUS_SIE);
+  c_sstatus(SSTATUS_SIE);
 }
 
 // are device interrupts enabled?

--- a/kernel/spinlock.c
+++ b/kernel/spinlock.c
@@ -91,7 +91,7 @@ push_off(void)
   // disable interrupts to prevent an involuntary context
   // switch while using mycpu().
   uint64 flags = rc_sstatus(SSTATUS_SIE);
-  int old = flags & SSTATUS_SIE;
+  int old = !!(flags & SSTATUS_SIE);
 
   if(mycpu()->noff == 0)
     mycpu()->intena = old;

--- a/kernel/spinlock.c
+++ b/kernel/spinlock.c
@@ -88,11 +88,10 @@ holding(struct spinlock *lk)
 void
 push_off(void)
 {
-  int old = intr_get();
-
   // disable interrupts to prevent an involuntary context
   // switch while using mycpu().
-  intr_off();
+  uint64 flags = rc_sstatus(SSTATUS_SIE);
+  int old = flags & SSTATUS_SIE;
 
   if(mycpu()->noff == 0)
     mycpu()->intena = old;


### PR DESCRIPTION
Currently, interrupt manipulations are completed by several instructions. For example,

```
void
push_off(void)
{
  int old = intr_get(); => csrr    a5, sstatus
                           mv      s1, a5
  intr_off();           => csrr    a5, sstatus
                           andi    a5, a5, -3
                           csrw    sstatus, a5
  ...                      ^^^^^^^^^^^^^^^^^^^
}                          At this point, interrupts are actually
                           disabled; before this, the CPU can still
                           be interrupted.
```

This commit uses the CSR set, clear and read-clear instructions to make interrupt manipulation more efficient and reliable.

Reference:
https://elixir.bootlin.com/linux/v6.15/source/arch/riscv/include/asm/irqflags.h#L18-L34 https://riscv.github.io/riscv-isa-manual/snapshot/unprivileged/#csrinsts