### PR TITLE
Create per-CPU tick counter

### DIFF
--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -137,10 +137,7 @@ int             fetchaddr(uint64, uint64*);
 void            syscall();
 
 // trap.c
-extern uint     ticks;
-void            trapinit(void);
 void            trapinithart(void);
-extern struct spinlock tickslock;
 void            prepare_return(void);
 
 // uart.c

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -20,7 +20,6 @@ main()
     kvminit();       // create kernel page table
     kvminithart();   // turn on paging
     procinit();      // process table
-    trapinit();      // trap vectors
     trapinithart();  // install kernel trap vector
     plicinit();      // set up interrupt controller
     plicinithart();  // ask PLIC for device interrupts

--- a/kernel/param.h
+++ b/kernel/param.h
@@ -12,4 +12,4 @@
 #define FSSIZE       2000  // size of file system in blocks
 #define MAXPATH      128   // maximum file path name
 #define USERSTACK    1     // user stack pages
-
+#define CACHE_LINE_SIZE (64) // 64 byte line size

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -552,7 +552,7 @@ sleep(void *chan, struct spinlock *lk)
   // so it's okay to release lk.
 
   acquire(&p->lock);  //DOC: sleeplock1
-  release(lk);
+  (lk) ? release(lk) : pop_off();
 
   // Go to sleep.
   p->chan = chan;
@@ -565,7 +565,7 @@ sleep(void *chan, struct spinlock *lk)
 
   // Reacquire original lock.
   release(&p->lock);
-  acquire(lk);
+  (lk) ? acquire(lk) : push_off();
 }
 
 // Wake up all processes sleeping on channel chan.

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -6,6 +6,7 @@
 #include "spinlock.h"
 #include "proc.h"
 #include "vm.h"
+#include "tick.h"
 
 uint64
 sys_exit(void)
@@ -64,25 +65,31 @@ sys_sbrk(void)
   return addr;
 }
 
+// defined in trap.c
+extern struct tick ticks[];
+
 uint64
 sys_pause(void)
 {
   int n;
-  uint ticks0;
+  uint tick0;
+  struct tick *tick;
 
   argint(0, &n);
   if(n < 0)
     n = 0;
-  acquire(&tickslock);
-  ticks0 = ticks;
-  while(ticks - ticks0 < n){
+
+  push_off();
+  tick = &ticks[cpuid()];
+  tick0 = tick->count;
+  while(tick->count - tick0 < n){
     if(killed(myproc())){
-      release(&tickslock);
+      pop_off();
       return -1;
     }
-    sleep(&ticks, &tickslock);
+    sleep(tick, 0);
   }
-  release(&tickslock);
+  pop_off();
   return 0;
 }
 
@@ -101,9 +108,10 @@ uint64
 sys_uptime(void)
 {
   uint xticks;
-
-  acquire(&tickslock);
-  xticks = ticks;
-  release(&tickslock);
+  struct tick *tick;
+  push_off();
+  tick = &ticks[cpuid()];
+  xticks = tick->count;
+  pop_off();
   return xticks;
 }

--- a/kernel/tick.h
+++ b/kernel/tick.h
@@ -1,0 +1,6 @@
+#include "types.h"
+#include "param.h"
+
+struct tick {
+  uint count;
+} __attribute__((aligned(CACHE_LINE_SIZE)));

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -5,9 +5,9 @@
 #include "spinlock.h"
 #include "proc.h"
 #include "defs.h"
+#include "tick.h"
 
-struct spinlock tickslock;
-uint ticks;
+struct tick ticks[NCPU];
 
 extern char trampoline[], uservec[];
 
@@ -15,12 +15,6 @@ extern char trampoline[], uservec[];
 void kernelvec();
 
 extern int devintr();
-
-void
-trapinit(void)
-{
-  initlock(&tickslock, "time");
-}
 
 // set up to take exceptions and traps while in the kernel.
 void
@@ -164,12 +158,10 @@ kerneltrap()
 void
 clockintr()
 {
-  if(cpuid() == 0){
-    acquire(&tickslock);
-    ticks++;
-    wakeup(&ticks);
-    release(&tickslock);
-  }
+  struct tick *tick = 0;
+  tick = &ticks[cpuid()];
+  tick->count += 1;
+  wakeup(tick);
 
   // ask for the next timer interrupt. this also clears
   // the interrupt request. 1000000 is about a tenth

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1052,6 +1052,36 @@ reparent2(char *s)
   exit(0);
 }
 
+void
+consleep(char *s)
+{
+  enum { N = 32 };
+  int pids[N] = { 0 };
+  pids[0] = getpid();
+
+  for(int i = 1; i < N; i++){
+    pids[i] = fork();
+    if(pids[i] < 0){
+      printf("fork failed\n");
+      exit(1);
+    }
+    if(pids[i] > 0)
+      continue;
+    if(pause(pids[i-1] % 11) < 0){
+      printf("sleep failed\n");
+      exit(1);
+    }
+    exit(0);
+  }
+
+  int xstatus;
+  for(int i = 1; i < N; i++){
+    wait(&xstatus);
+    if(xstatus != 0)
+      exit(1);
+  }
+}
+
 // allocate all mem, free it, and allocate again
 void
 mem(char *s)
@@ -2779,6 +2809,7 @@ struct test {
   {forkfork, "forkfork"},
   {forkforkfork, "forkforkfork"},
   {reparent2, "reparent2"},
+  {consleep, "consleep"},
   {mem, "mem"},
   {sharedfd, "sharedfd"},
   {fourfiles, "fourfiles"},


### PR DESCRIPTION
It is intuitive to allow each CPU have its own tick counter.

This commit provides the key concepts of per-CPU variable and serves as a warm-up for the Lock Lab: memory allocator.

(*) Preemption

Accessing per-CPU variable must disable preemption to avoid data races.

For example, a process tries to update the tick counter of CPU0, but is switched to another CPU before store instruction, and the subsequent process running on CPU0 also wants to update the tick counter of CPU0.

```
tick++ => load    a5, (tick)
          addi    a5, a5, 1
          store   a5, (tick)
```

In xv6, disabling and enabling preemption can be controlled by push_off() and pop_off().

(*) Remove lock contention and deadlock

Previously, interrupts had to be disabled before holding the tickslock in sys_uptime() to avoid deadlock, as this lock was also used in the interrupt context, i.e., clockintr().

Note: however, in xv6, invoking sleep() requires holding a lock, and we need to adjust this restriction.

(*) False sharing

```
+-----------------+  +-----------------+
|            CPU0 |  |            CPU1 |
| L1 cache        |  | L1 cache        |
| +-------------+ |  | +-------------+ |
| | tick0 tick1 | |  | | tick0 tick1 | |
| +-------------+ |  | +-------------+ |
+-----------------+  +-----------------+

L2 cache
+-------------+
| tick0 tick1 |
+-------------+
```

Per-CPU variables should be placed in different cache lines to avoid false sharing, that is,

```
+-----------------+  +-----------------+
|            CPU0 |  |            CPU1 |
| L1 cache        |  | L1 cache        |
| +-------------+ |  | +-------------+ |
| | tick0       | |  | | tick1       | |
| +-------------+ |  | +-------------+ |
+-----------------+  +-----------------+

L2 cache
+-------------+
| tick0       |
+-------------+
| tick1       |
+-------------+
```

In addition, per-CPU tick counter also improves fairness. Previously, wakeup() was handled only by CPU0 in clockintr(). Ideally, each CPU should have its own sleep queue.
https://github.com/segfauIt/xv6-riscv/blob/e60f18e/kernel/proc.c#L555-L626
