### PR TITLE
ls: simplify path handling using chdir

### DIFF
--- a/user/ls.c
+++ b/user/ls.c
@@ -5,19 +5,11 @@
 #include "kernel/fcntl.h"
 
 char*
-fmtname(char *path)
+fmtname(char *p)
 {
   static char buf[DIRSIZ+1];
-  char *p;
-
-  // Find first character after last slash.
-  for(p=path+strlen(path); p >= path && *p != '/'; p--)
-    ;
-  p++;
 
   // Return blank-padded name.
-  if(strlen(p) >= DIRSIZ)
-    return p;
   memmove(buf, p, strlen(p));
   memset(buf+strlen(p), ' ', DIRSIZ-strlen(p));
   buf[sizeof(buf)-1] = '\0';
@@ -27,7 +19,6 @@ fmtname(char *path)
 void
 ls(char *path)
 {
-  char buf[512], *p;
   int fd;
   struct dirent de;
   struct stat st;
@@ -43,32 +34,24 @@ ls(char *path)
     return;
   }
 
-  switch(st.type){
-  case T_DEVICE:
-  case T_FILE:
+  if (st.type == T_FILE || st.type == T_DEVICE){
     printf("%s %d %d %d\n", fmtname(path), st.type, st.ino, (int) st.size);
-    break;
-
-  case T_DIR:
-    if(strlen(path) + 1 + DIRSIZ + 1 > sizeof buf){
-      printf("ls: path too long\n");
-      break;
+  } else {
+    if (chdir(path) < 0){
+      printf("ls: cannot cd %s\n", path);
+      close(fd);
+      return;
     }
-    strcpy(buf, path);
-    p = buf+strlen(buf);
-    *p++ = '/';
+
     while(read(fd, &de, sizeof(de)) == sizeof(de)){
       if(de.inum == 0)
         continue;
-      memmove(p, de.name, DIRSIZ);
-      p[DIRSIZ] = 0;
-      if(stat(buf, &st) < 0){
-        printf("ls: cannot stat %s\n", buf);
+      if(stat(de.name, &st) < 0){
+        printf("ls: cannot stat %s\n", de.name);
         continue;
       }
-      printf("%s %d %d %d\n", fmtname(buf), st.type, st.ino, (int) st.size);
+      printf("%s %d %d %d\n", fmtname(de.name), st.type, st.ino, (int) st.size);
     }
-    break;
   }
   close(fd);
 }
@@ -76,13 +59,21 @@ ls(char *path)
 int
 main(int argc, char *argv[])
 {
-  int i;
+  int i, pid;
 
   if(argc < 2){
     ls(".");
     exit(0);
   }
-  for(i=1; i<argc; i++)
-    ls(argv[i]);
+  for(i=1; i<argc; i++){
+    pid = fork();
+    if(pid < 0)
+      break;
+    if (pid == 0){
+      ls(argv[i]);
+      exit(0);
+    } else
+      wait(0);
+  }
   exit(0);
 }


### PR DESCRIPTION
Use `chdir()` to eliminate the fixed buffer approach. Use `fork()` to avoid conflicts when listing multiple directories. This approach is safer and simpler than the previous path concatenation method.

Note: Shell argument limit (MAXARGS=10) provides natural bounds for fork usage.