### PR TITLE
Makefile: Fix building xv6 with Ubuntu 25.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
 CFLAGS = -Wall -Werror -Wno-unknown-attributes -O -fno-omit-frame-pointer -ggdb -gdwarf-2
+CFLAGS += -march=rv64gc
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
 CFLAGS += -ffreestanding
@@ -89,7 +90,7 @@ $K/kernel: $(OBJS) $K/kernel.ld
 	$(OBJDUMP) -t $K/kernel | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $K/kernel.sym
 
 $K/%.o: $K/%.S
-	$(CC) -g -c -o $@ $<
+	$(CC) -march=rv64gc -g -c -o $@ $<
 
 tags: $(OBJS)
 	etags kernel/*.S kernel/*.c


### PR DESCRIPTION
In Ubuntu 25.10 the default target ISA in GCC 15 has been changed to RVA23U64. QEMU defaults to a rv64gc CPU.

Explicitly specify the build target architecture as rv64gc.

Link: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2128545