### PR TITLE
Xv6 new system calls addition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ UPROGS=\
 	$U/_logstress\
 	$U/_forphan\
 	$U/_dorphan\
+	$U/_fork\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -183,3 +183,6 @@ void            virtio_disk_intr(void);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x)/sizeof((x)[0]))
+
+int             forkwitharg(int);
+uint64           sys_getppid(void);

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -688,3 +688,55 @@ procdump(void)
     printf("\n");
   }
 }
+
+int
+forkwitharg(int value)
+{
+    int i, pid;
+    struct proc *np;
+    struct proc *p = myproc();
+
+    // Allocate process
+    if((np = allocproc()) == 0){
+        return -1;
+    }
+
+    // Save the argument in new process
+    np->fork_arg = value;
+
+    // Copy user memory from parent to child
+    if(uvmcopy(p->pagetable, np->pagetable, p->sz) < 0){
+        freeproc(np);
+        release(&np->lock);
+        return -1;
+    }
+    np->sz = p->sz;
+
+    // Copy saved user registers
+    *(np->trapframe) = *(p->trapframe);
+
+    // Return value for child
+    np->trapframe->a0 = 0;
+
+    // Increment reference counts on open file descriptors
+    for(i = 0; i < NOFILE; i++)
+        if(p->ofile[i])
+            np->ofile[i] = filedup(p->ofile[i]);
+    np->cwd = idup(p->cwd);
+
+    safestrcpy(np->name, p->name, sizeof(p->name));
+
+    pid = np->pid;
+
+    release(&np->lock);
+
+    acquire(&wait_lock);
+    np->parent = p;
+    release(&wait_lock);
+
+    acquire(&np->lock);
+    np->state = RUNNABLE;
+    release(&np->lock);
+
+    return pid;
+}

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -104,4 +104,6 @@ struct proc {
   struct file *ofile[NOFILE];  // Open files
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
+
+  int fork_arg;
 };

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,9 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_forkwitharg(void);
+extern uint64 sys_getforkarg(void);
+extern uint64 sys_getppid(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +129,9 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_forkwitharg] sys_forkwitharg,
+[SYS_getforkarg] sys_getforkarg,
+[SYS_getppid] sys_getppid,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,6 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_forkwitharg 23
+#define SYS_getforkarg 24
+#define SYS_getppid 25

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -107,3 +107,29 @@ sys_uptime(void)
   release(&tickslock);
   return xticks;
 }
+
+uint64
+sys_forkwitharg(void)
+{
+    int arg;
+    
+    // Get the argument passed from user space
+    argint(0, &arg);
+    
+    return forkwitharg(arg);
+}
+
+int
+sys_getforkarg(void)
+{
+    struct proc *p = myproc();
+    return p->fork_arg;
+}
+
+uint64 
+sys_getppid(void)
+{
+    struct proc *p=myproc();
+    if(p->parent) return p->parent->pid;
+    return -1;
+}

--- a/user/fork.c
+++ b/user/fork.c
@@ -1,0 +1,61 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+int custom_atoi(const char *str) {
+    int result = 0;
+    int sign = 1;
+
+    // Check for negative sign
+    if (*str == '-') {
+        sign = -1;
+        str++;
+    }
+
+    // Convert characters to integer
+    while (*str >= '0' && *str <= '9') {
+        result = result * 10 + (*str - '0');
+        str++;
+    }
+
+    return sign * result;
+}
+
+int
+main(int argc, char *argv[])
+{
+    int pid;
+
+    char buffer[10];
+    int n;
+
+    printf("Enter a number to pass to child : ");
+
+    n=read(0,buffer,sizeof(buffer));
+
+    if(n<0)
+    {
+        printf("Error reading input\n");
+        exit(0);
+    }
+
+    buffer[n-1]='\0';
+    int arg=custom_atoi(buffer);
+    pid = forkwitharg(arg);  // Pass test value 42
+    if(pid < 0){
+        printf("forkwitharg failed\n");
+        exit(1);
+    }
+    
+    if(pid == 0){
+        // Child process
+        printf("Child process created with argument: %d\n", getforkarg());
+        printf("Child Pid : %u, Parent Pid : %lu\n",getpid(),getppid());
+    } else {
+        // Parent process
+        wait(0);
+        printf("In parent process\n");
+        printf("Parent Pid : %u, Parent's Parent Pid : %lu\n",getpid(),getppid());
+        // wait(0);
+    }
+    exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -24,6 +24,10 @@ int getpid(void);
 char* sys_sbrk(int,int);
 int pause(int);
 int uptime(void);
+int forkwitharg(int);
+int getforkarg(void);
+uint64 getppid(void);
+
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -42,3 +42,6 @@ entry("getpid");
 entry("sbrk");
 entry("pause");
 entry("uptime");
+entry("forkwitharg");
+entry("getforkarg");
+entry("getppid");


### PR DESCRIPTION
### Overview
This pull request adds three new system calls to xv6-riscv, enhancing process creation and parent-child process interaction.

### System Calls Implemented
1. **forkwitharg()** – Creates a new process and allows passing an argument from parent to child.
2. **getforkarg()** – Retrieves the argument passed using forkwitharg().
3. **getppid()** – Returns the parent process ID of the calling process.

### Files Modified
- kernel/syscall.h – Added new syscall identifiers (`SYS_forkwitharg`, `SYS_getforkarg`, `SYS_getppid`)
- kernel/proc.h – Added a new field `fork_arg` to the `struct proc`
- kernel/proc.c – Implemented logic for `forkwitharg` to handle argument passing
- kernel/sysproc.c – Added `sys_forkwitharg`, `sys_getforkarg`, `sys_getppid` syscall handlers
- kernel/defs.h – Declared prototypes for the new system calls
- kernel/syscall.c – Linked new system calls in the syscall table
- user/user.h – Declared the new system calls for user-space programs
- user/usys.pl – Added entries for `forkwitharg`, `getforkarg`, and `getppid`
- user/fork.c – User program demonstrating the use of the new system calls
- Makefile – Added the user program `fork` to the compilation list

### Testing
- Verified functionality using the `fork` user program.
- All system calls execute correctly under QEMU.
- Existing xv6 functionality remains unaffected.
