### PR TITLE
Fix infinite incrementing pid in pipe

### DIFF
--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -155,6 +155,7 @@ found:
 static void
 freeproc(struct proc *p)
 {
+  nextpid--;
   if(p->trapframe)
     kfree((void*)p->trapframe);
   p->trapframe = 0;


### PR DESCRIPTION
When creating pipe between two or more processes, pid is infinitly incrementing. Fixed by decrementing nextpid in freeproc