### PR TITLE
test-xv6.py: Do not fail `rm fs.img` if run after `make clean`

### DIFF
--- a/test-xv6.py
+++ b/test-xv6.py
@@ -32,7 +32,7 @@ class QEMU(object):
 
     def reset_fs(self):
         try:
-            run(["rm", "fs.img"], check=True)
+            run(["rm", "-f", "fs.img"], check=True)
             run(["make", "fs.img"], check=True)
         except subprocess.CalledProcessError as e:
             print(f"Command failed with exit code {e.returncode}")


### PR DESCRIPTION
When these commands are run:

    $ make clean
    $ ./test-xv6.py -q usertests

The `test-xv6.py` script will report the following error messages and produce no more output for a while:

    rm: cannot remove 'fs.img': No such file or directory
    Command failed with exit code 1

This is because `test-xv6.py` effectively runs these system commands for `usertests`:

    $ make kernel/kernel # In QEMU.build_xv6()
    $ rm fs.img          # In QEMU.reset_fs()
    $ make fs.img        # In QEMU.reset_fs()
    $ make qemu          # In QEMU.__init__()

`make clean` deletes `fs.img`, and `make kernel/kernel` does not build `fs.img`, so when the `rm fs.img` command is run, `fs.img` does not exist, causing `rm` to fail.

To fix this issue, use the `-f` option of `rm` to not let it fail when `fs.img` does not exist.