### PR TITLE
Fix redundant MIE_STIE enable in timerinit (Issue #422)

### DIFF
--- a/kernel/start.c
+++ b/kernel/start.c
@@ -52,9 +52,6 @@ start()
 void
 timerinit()
 {
-  // enable supervisor-mode timer interrupts.
-  w_mie(r_mie() | MIE_STIE);
-  
   // enable the sstc extension (i.e. stimecmp).
   w_menvcfg(r_menvcfg() | (1L << 63)); 
   


### PR DESCRIPTION
This PR removes the redundant `w_mie(r_mie() | MIE_STIE);` line in timerinit().

Reason:
- Timer interrupts are already enabled in start() via SIE_STIE.
- The interrupt is delegated to S-mode, so only SIE matters.
- The MIE_STIE write in timerinit() is redundant and unnecessary.

This follows the RISC-V spec and discussion in Issue #422.

Closes: #422
