### PR TITLE
Don't exclude mkfs.c in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ entryother
 initcode
 initcode.out
 kernelmemfs
-mkfs
+mkfs/mkfs
+!mkfs/mkfs.c
 kernel/kernel
 user/usys.S
 .gdbinit


### PR DESCRIPTION
The current `.gitgnore` directive of `mkfs` excludes the entire `mkfs` directory, which includes the `mkfs/mkfs.c` file. I assume the intent was to only exclude the produced `mkfs/mkfs` binary. This PR makes that more clear.

I understand this is not an issue that would arise when working with this repo as the `.c` file is explicitly added, so I would understand if you choose to ignore the PR. The only reason I ran into it was because I incorporated the xv6 codebase into a bigger repo for my class, and thus it was a fresh git repo without this repo's history of explicitly including the `.c` file. and so the initial commit and dissemination ended up excluding the `mkfs` directory.

 