### PR TITLE
Introduce minor `iunlockput` improvements

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -24,7 +24,7 @@
 #define min(a, b) ((a) < (b) ? (a) : (b))
 // there should be one superblock per disk device, but we run with
 // only one device
-struct superblock sb; 
+struct superblock sb;
 
 // Read the super block.
 static void
@@ -154,6 +154,9 @@ bfree(int dev, uint b)
 //   iunlock(ip)
 //   iput(ip)
 //
+// In the sequence above, the functions iunlock() and iput()
+// can also be replaced with the equivalent iunlockput().
+//
 // ilock() is separate from iget() so that system calls can
 // get a long-term reference to an inode (as for an open file)
 // and only lock it for short periods (e.g., in read()).
@@ -183,7 +186,7 @@ void
 iinit()
 {
   int i = 0;
-  
+
   initlock(&itable.lock, "itable");
   for(i = 0; i < NINODE; i++) {
     initsleeplock(&itable.inode[i].lock, "inode");

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -388,8 +388,7 @@ ireclaim(int dev)
     if (ip) {
       begin_op();
       ilock(ip);
-      iunlock(ip);
-      iput(ip);
+      iunlockput(ip);
       end_op();
     }
   }


### PR DESCRIPTION
Justifications for the changes made have been included in the commits themselves. I am attaching them here for your own convenience: 

[Include iunlockput() in inode docs](https://github.com/mit-pdos/xv6-riscv/commit/b2175003c78f6f3bac9a57dcb9c07ba9ab51ee23): "Plus two whitespace-related fixes by my editor, because why not."

[ireclaim: Use iunlockput](https://github.com/mit-pdos/xv6-riscv/commit/165da9877a688494ac9dc15dc6878c7dc0ec3f9f): "This is basically equivalent, but given the educational context, ireclaim is a primary example: It initiates an operation, modifies an inode (which results in buffer cache and log write operations under the hood. Then, the operation ends. Given this context, this nitpick makes sense."