### PR TITLE
  kernel: remove unused uartgetc declaration from defs.h

### DIFF
--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -148,7 +148,7 @@ void            uartinit(void);
 void            uartintr(void);
 void            uartwrite(char [], int);
 void            uartputc_sync(int);
-int             uartgetc(void);
+
 
 // vm.c
 void            kvminit(void);


### PR DESCRIPTION
uartgetc() is used only within kernel/uart.c. but it is currently declared in kernel/defs.h alongside the UART interfaces that are used by other kernel files.

Remove that declaration from defs.h to keep the exported UART interface surface smaller and cleaner. This DOES NOT change behavior.

Build tested with:

make kernel/kernel