### PR TITLE
.gitignore: don't ignore entire mkfs/ tree, just mkfs/mkfs binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ entryother
 initcode
 initcode.out
 kernelmemfs
-mkfs
+mkfs/mkfs
 kernel/kernel
 user/usys.S
 .gdbinit


### PR DESCRIPTION
Otherwise, fresh repositories initialized with the xv6 tree will ignore the `mkfs/mkfs.c` file.