### PR TITLE
fix comment for 'prepare_return'

### DIFF
--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -34,11 +34,11 @@ extern struct cpu cpus[NCPU];
 // uservec in trampoline.S saves user registers in the trapframe,
 // then initializes registers from the trapframe's
 // kernel_sp, kernel_hartid, kernel_satp, and jumps to kernel_trap.
-// usertrapret() and userret in trampoline.S set up
+// prepare_return() and userret in trampoline.S set up
 // the trapframe's kernel_*, restore user registers from the
 // trapframe, switch to the user page table, and enter user space.
 // the trapframe includes callee-saved user registers like s0-s11 because the
-// return-to-user path via usertrapret() doesn't return through
+// return-to-user path via prepare_return() doesn't return through
 // the entire kernel call stack.
 struct trapframe {
   /*   0 */ uint64 kernel_satp;   // kernel page table

--- a/kernel/trampoline.S
+++ b/kernel/trampoline.S
@@ -145,5 +145,5 @@ userret:
         ld a0, 112(a0)
         
         # return to user mode and user pc.
-        # usertrapret() set up sstatus and sepc.
+        # prepare_return() set up sstatus and sepc.
         sret


### PR DESCRIPTION
The function `usertrapret()` has been replaced by `prepare_return()` in the codebase.