### PR TITLE
Add ps syscall and userspace ps command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ UPROGS=\
 	$U/_logstress\
 	$U/_forphan\
 	$U/_dorphan\
+	$U/_ps\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ UPROGS=\
 	$U/_mkdir\
 	$U/_rm\
 	$U/_sh\
+	$U/_sleep\
 	$U/_stressfs\
 	$U/_usertests\
 	$U/_grind\

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -96,6 +96,7 @@ void            sched(void);
 void            sleep(void*, struct spinlock*);
 void            userinit(void);
 int             kwait(uint64);
+int             kps(uint64, int);
 void            wakeup(void*);
 void            yield(void);
 int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -4,6 +4,7 @@
 #include "riscv.h"
 #include "spinlock.h"
 #include "proc.h"
+#include "ps.h"
 #include "defs.h"
 
 struct cpu cpus[NCPU];
@@ -687,4 +688,41 @@ procdump(void)
     printf("%d %s %s", p->pid, state, p->name);
     printf("\n");
   }
+}
+
+// Copy process info to userspace.
+// Iterate through proc table and copy RUNNABLE/RUNNING/SLEEPING processes.
+// Returns number of processes copied, or -1 on error.
+int
+kps(uint64 addr, int max)
+{
+  if(max < 0 || max > 256)
+    return -1;
+
+  struct proc *cur = myproc();
+  struct proc *p;
+  int n = 0;
+
+  for(p = proc; p < &proc[NPROC] && n < max; p++){
+    struct pinfo pi;
+    int include = 0;
+
+    acquire(&p->lock);
+    if(p->state == SLEEPING || p->state == RUNNABLE || p->state == RUNNING){
+      pi.pid = p->pid;
+      pi.state = p->state;
+      pi.sz = p->sz;
+      safestrcpy(pi.name, p->name, sizeof(pi.name));
+      include = 1;
+    }
+    release(&p->lock);
+
+    if(include){
+      if(copyout(cur->pagetable, addr + n * sizeof(pi), (char *)&pi, sizeof(pi)) < 0)
+        return -1;
+      n++;
+    }
+  }
+
+  return n;
 }

--- a/kernel/ps.h
+++ b/kernel/ps.h
@@ -1,0 +1,18 @@
+#ifndef _KERNEL_PS_H_
+#define _KERNEL_PS_H_
+
+#define PS_NAME_LEN 16
+
+// Matches enum procstate in proc.h
+#define PS_SLEEPING 2
+#define PS_RUNNABLE 3
+#define PS_RUNNING  4
+
+struct pinfo {
+  int pid;
+  int state;
+  uint64 sz;
+  char name[PS_NAME_LEN];
+};
+
+#endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_ps(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_ps]      sys_ps,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_ps     22

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -37,6 +37,17 @@ sys_wait(void)
 }
 
 uint64
+sys_ps(void)
+{
+  uint64 p;
+  int max;
+
+  argaddr(0, &p);
+  argint(1, &max);
+  return kps(p, max);
+}
+
+uint64
 sys_sbrk(void)
 {
   uint64 addr;

--- a/user/ps.c
+++ b/user/ps.c
@@ -1,0 +1,39 @@
+#include "kernel/types.h"
+#include "kernel/ps.h"
+#include "user/user.h"
+
+#define MAX_PROCS 64
+
+static char *
+state_name(int s)
+{
+  switch(s){
+  case PS_SLEEPING:
+    return "sleep";
+  case PS_RUNNABLE:
+    return "runnable";
+  case PS_RUNNING:
+    return "running";
+  default:
+    return "?";
+  }
+}
+
+int
+main(void)
+{
+  struct pinfo list[MAX_PROCS];
+  int n = ps(list, MAX_PROCS);
+
+  if(n < 0){
+    fprintf(2, "ps: syscall failed\n");
+    exit(1);
+  }
+
+  printf("PID\tSTATE\t\tSIZE(KB)\tNAME\n");
+  for(int i = 0; i < n; i++){
+    printf("%d\t%s\t\t%ld\t\t%s\n", list[i].pid, state_name(list[i].state), list[i].sz / 1024, list[i].name);
+  }
+
+  exit(0);
+}

--- a/user/sleep.c
+++ b/user/sleep.c
@@ -1,0 +1,18 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+  int i;
+
+  if(argc < 2){
+    fprintf(2, "usage: sleep seconds\n");
+    exit(1);
+  }
+  i = atoi(argv[1]);
+  if(i < 0)
+    i = 0;
+  pause(i * 100);
+  exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -1,5 +1,6 @@
 #define SBRK_ERROR ((char *)-1)
 
+struct pinfo;
 struct stat;
 
 // system calls
@@ -24,6 +25,7 @@ int getpid(void);
 char* sys_sbrk(int,int);
 int pause(int);
 int uptime(void);
+int ps(struct pinfo*, int);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -42,3 +42,4 @@ entry("getpid");
 entry("sbrk");
 entry("pause");
 entry("uptime");
+entry("ps");


### PR DESCRIPTION
I implemented a new `ps`  feature in xv6 that exposes active process information from kernel space to userspace through a dedicated syscall.

This PR adds a full end-to-end syscall path 
(userspace -> syscall stub -> syscall dispatcher -> kernel worker -> copyout -> userspace print)
and a simple `ps`  command to validate behaviour from the shell.

**What I changed**
- Added a new syscall number for `ps`
- Added kernel syscall handler and dispatcher wiring
- Implemented kernel process walker that:
  - Iterates process table
  - Collects active processes `SLEEPING`, `RUNNABLE`, `RUNNING` 
  - Copies process info safely back to userspace `copyout`
- Added shared process info struct for kernel-userspace contract
- Added userspace syscall declaration and stub generation
- Added userspace `ps` command
- Updated build config to include `ps` program in user binaries

**Why this change**
The goal was to implement a realistic syscall pattern and practice core OS concepts:
- argument passing from userspace to kernel
- safe memory transfer across the privilege boundary
- process table traversal with locking
- syscall dispatch integration
**Sample output**
<img width="402" height="122" alt="image" src="https://github.com/user-attachments/assets/3449e3c6-f2d0-4795-a39f-a4c242370d8d" /> 

**How I tested**
- Built xv6 and booted in QEMU
- Ran `ps` at idle and verified base processes (init, sh, ps )
<img width="455" height="191" alt="image" src="https://github.com/user-attachments/assets/b87fcdd2-bfca-4910-a15b-3253df37bdf3" /> <br> <br>
- Spawned background workloads (e.g. sleep) and confirmed they appear in `ps`
<img width="455" height="143" alt="image" src="https://github.com/user-attachments/assets/7cc37267-6dfc-4a92-b9d6-12e59a131070" /><br> <br>
- Re-ran `ps` multiple times to confirm stable syscall behaviour and expected state transitions [After 10 sec]
<img width="455" height="206" alt="image" src="https://github.com/user-attachments/assets/dbc4039c-9f0c-4b47-9cb1-f4d4b4cd951f" /><br> <br>


Notes
- The command intentionally shows only active processes for clarity.
- `ps` appears as running while it is executing, which is expected.