### PR TITLE
Enhance (spin|sleep)lock code readability, ~~get tighter spinlock loops~~

### DIFF
--- a/README
+++ b/README
@@ -26,8 +26,8 @@ Kolontsov, Austin Liew, l0stman, Pavan Maddamsetti, Imbar Marinescu,
 Yandong Mao, Matan Shabtay, Hitoshi Mitake, Carmi Merimovich,
 mes900903, Mark Morrissey, mtasm, Joel Nider, Hayato Ohhashi,
 OptimisticSide, papparapa, phosphagos, Harry Porter, Greg Price, Zheng
-qhuo, Quancheng, RayAndrew, Jude Rich, segfault, Ayan Shafqat, Eldar
-Sehayek, Yongming Shen, Fumiya Shigemitsu, snoire, Taojie, Cam Tenny,
+qhuo, Quancheng, RayAndrew, Jude Rich, Enzo Romano, segfault, Ayan Shafqat,
+Eldar Sehayek, Yongming Shen, Fumiya Shigemitsu, snoire, Taojie, Cam Tenny,
 tyfkda, Warren Toomey, Stephen Tu, Alissa Tung, Rafael Ubal, unicornx,
 Amane Uehara, Pablo Ventura, Luc Videau, Xi Wang, WaheedHafez, Keiichi
 Watanabe, Lucas Wolf, Nicolas Wolovick, wxdao, Grant Wu, x653, Andy

--- a/kernel/sleeplock.c
+++ b/kernel/sleeplock.c
@@ -14,7 +14,7 @@ initsleeplock(struct sleeplock *lk, char *name)
 {
   initlock(&lk->lk, "sleep lock");
   lk->name = name;
-  lk->locked = 0;
+  lk->locked = SPINLOCK_FREE;
   lk->pid = 0;
 }
 
@@ -22,10 +22,10 @@ void
 acquiresleep(struct sleeplock *lk)
 {
   acquire(&lk->lk);
-  while (lk->locked) {
+  while (lk->locked == SPINLOCK_HELD) {
     sleep(lk, &lk->lk);
   }
-  lk->locked = 1;
+  lk->locked = SPINLOCK_HELD;
   lk->pid = myproc()->pid;
   release(&lk->lk);
 }
@@ -34,7 +34,7 @@ void
 releasesleep(struct sleeplock *lk)
 {
   acquire(&lk->lk);
-  lk->locked = 0;
+  lk->locked = SPINLOCK_FREE;
   lk->pid = 0;
   wakeup(lk);
   release(&lk->lk);
@@ -46,10 +46,7 @@ holdingsleep(struct sleeplock *lk)
   int r;
   
   acquire(&lk->lk);
-  r = lk->locked && (lk->pid == myproc()->pid);
+  r = (lk->locked == SPINLOCK_HELD) && (lk->pid == myproc()->pid);
   release(&lk->lk);
   return r;
 }
-
-
-

--- a/kernel/spinlock.c
+++ b/kernel/spinlock.c
@@ -12,7 +12,7 @@ void
 initlock(struct spinlock *lk, char *name)
 {
   lk->name = name;
-  lk->locked = 0;
+  lk->locked = SPINLOCK_FREE;
   lk->cpu = 0;
 }
 
@@ -34,7 +34,7 @@ acquire(struct spinlock *lk)
   // the C compiler and the processor to not move loads or stores
   // past this point, to ensure that the critical section's memory
   // references happen strictly after the lock is acquired.
-  while(__atomic_exchange_n(&lk->locked, 1, __ATOMIC_ACQUIRE) != 0)
+  while(__atomic_exchange_n(&lk->locked, SPINLOCK_HELD, __ATOMIC_ACQUIRE) == SPINLOCK_HELD)
     ;
 
   // Record info about lock acquisition for holding() and debugging.
@@ -69,7 +69,7 @@ release(struct spinlock *lk)
   //
   // On RISC-V, this generates a fence instruction before the store:
   //   fence rw,w
-  __atomic_store_n(&lk->locked, 0, __ATOMIC_RELEASE);
+  __atomic_store_n(&lk->locked, SPINLOCK_FREE, __ATOMIC_RELEASE);
 
   pop_off();
 }
@@ -80,7 +80,7 @@ int
 holding(struct spinlock *lk)
 {
   int r;
-  r = (lk->locked && lk->cpu == mycpu());
+  r = (lk->locked == SPINLOCK_HELD) && (lk->cpu == mycpu());
   return r;
 }
 

--- a/kernel/spinlock.h
+++ b/kernel/spinlock.h
@@ -7,3 +7,8 @@ struct spinlock {
   struct cpu *cpu;   // The cpu holding the lock.
 };
 
+// "Inverted" logic ahead!
+// This is done to get a tiny gain
+// for a tighter spinlock loop
+#define SPINLOCK_HELD 0
+#define SPINLOCK_FREE 1


### PR DESCRIPTION
I explicitly defined two constants, `SPINLOCK_FREE` and `SPINLOCK_HELD` to enhance code readability.

Then, by inverting the "traditional" spinlock value logic, we can get a tiny gain in the spinlock loop when compiled by current compilers.

The loop becomes just 1 instruction (plus 1 un-skippable conditional jump) instead of 2.

You can see the effect of this inversion on emitted RISC-V assembly [here (godbolt)](https://godbolt.org/z/6zGcK6dzv).

P.S. I am the same author of [this ticket](https://github.com/mit-pdos/xv6-riscv/issues/387#issuecomment-4491361782).