### PR TITLE
Helena A

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,8 @@ UPROGS=\
 	$U/_logstress\
 	$U/_forphan\
 	$U/_dorphan\
+	$U/_getcnt\
+
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -123,7 +123,9 @@ allocproc(void)
 
 found:
   p->pid = allocpid();
+  p->tickets = 1; //O processo recebe 1 ticket quando for alocado
   p->state = USED;
+  printf("DEBUG: alocado processo com tickets=%d\n", p->tickets);
 
   // Allocate a trapframe page.
   if((p->trapframe = (struct trapframe *)kalloc()) == 0){
@@ -279,6 +281,9 @@ kfork(void)
   // copy saved user registers.
   *(np->trapframe) = *(p->trapframe);
 
+  //Herda tickets do pai
+  np->tickets = p->tickets;
+
   // Cause fork to return 0 in the child.
   np->trapframe->a0 = 0;
 
@@ -356,6 +361,10 @@ kexit(int status)
   acquire(&p->lock);
 
   p->xstate = status;
+
+  tickets_totais = tickets_totais - p->tickets; //tira os tickets do processo que está acabando do total
+  p->tickets = 0; //Processo ao morrer tem tickets zerados
+
   p->state = ZOMBIE;
 
   release(&wait_lock);

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -688,3 +688,19 @@ procdump(void)
     printf("\n");
   }
 }
+
+extern int syscall_counts[];
+
+uint64
+sys_getcnt(void)
+{
+  int target_sys_num;
+
+  argint(0, &target_sys_num);
+
+  if(target_sys_num <= 0 || target_sys_num >= 30) {
+    return -1;
+  }
+
+  return syscall_counts[target_sys_num];
+}

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -91,6 +91,7 @@ struct proc {
   int killed;                  // If non-zero, have been killed
   int xstate;                  // Exit status to be returned to parent's wait
   int pid;                     // Process ID
+  int tickets;                 // Quantidade de tickets do processo - TP2
 
   // wait_lock must be held when using this:
   struct proc *parent;         // Parent process

--- a/kernel/pstat.h
+++ b/kernel/pstat.h
@@ -1,0 +1,16 @@
+//Funcao: define a estrutura que será retornada pela syscall `getpinfo()`
+
+#ifndef _KERNEL_PSTAT_H_
+#define _KERNEL_PSTAT_H_
+
+#include "types.h"
+
+#define NPROC 64
+
+struct pstat {
+  int pid;
+  int tickets;  // Número de bilhetes (lottery tickets)
+  int ticks;    // Quantos ticks foi escalonado para o processo
+};
+
+#endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -7,6 +7,8 @@
 #include "syscall.h"
 #include "defs.h"
 
+int syscall_counts[30] = {0};
+
 // Fetch the uint64 at addr from the current process.
 int
 fetchaddr(uint64 addr, uint64 *ip)
@@ -101,6 +103,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_getcnt(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +129,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_getcnt]  sys_getcnt,
 };
 
 void
@@ -136,6 +140,8 @@ syscall(void)
 
   num = p->trapframe->a7;
   if(num > 0 && num < NELEM(syscalls) && syscalls[num]) {
+    syscall_counts[num]++;
+
     // Use num to lookup the system call function for num, call it,
     // and store its return value in p->trapframe->a0
     p->trapframe->a0 = syscalls[num]();

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_getcnt 22

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -505,20 +505,3 @@ sys_pipe(void)
   }
   return 0;
 }
-
-uint64
-sys_getcnt(void)
-{
-  int target_sys_num;
-  
-  // argint(0, ...) pega o primeiro parâmetro passado para a syscall
-  argint(0, &target_sys_num); 
-
-  // Validação de segurança para evitar acessos fora do array
-  if(target_sys_num <= 0 || target_sys_num >= 30) {
-    return -1; 
-  }
-
-  // Retorna quantas vezes a syscall foi chamada
-  return syscall_counts[target_sys_num];
-}

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -16,6 +16,8 @@
 #include "file.h"
 #include "fcntl.h"
 
+extern int syscall_counts[];
+
 // Fetch the nth word-sized system call argument as a file descriptor
 // and return both the descriptor and the corresponding struct file.
 static int
@@ -502,4 +504,21 @@ sys_pipe(void)
     return -1;
   }
   return 0;
+}
+
+uint64
+sys_getcnt(void)
+{
+  int target_sys_num;
+  
+  // argint(0, ...) pega o primeiro parâmetro passado para a syscall
+  argint(0, &target_sys_num); 
+
+  // Validação de segurança para evitar acessos fora do array
+  if(target_sys_num <= 0 || target_sys_num >= 30) {
+    return -1; 
+  }
+
+  // Retorna quantas vezes a syscall foi chamada
+  return syscall_counts[target_sys_num];
 }

--- a/user/getcnt.c
+++ b/user/getcnt.c
@@ -1,0 +1,19 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+    if(argc != 2){
+        fprintf(2, "uso: getcnt <syscall_id>\n");
+        exit(1);
+    }
+    int id = atoi(argv[1]);
+    int count = getcnt(id);
+    if(count < 0){
+        fprintf(2, "getcnt: syscall id invalido: %d\n", id);
+        exit(1);
+    }
+    printf("syscall %d has been called %d times\n", id, count);
+    exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -24,6 +24,7 @@ int getpid(void);
 char* sys_sbrk(int,int);
 int pause(int);
 int uptime(void);
+int getcnt(int);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -42,3 +42,4 @@ entry("getpid");
 entry("sbrk");
 entry("pause");
 entry("uptime");
+entry("getcnt");

--- a/userchanges.diff
+++ b/userchanges.diff
@@ -1,0 +1,87 @@
+diff --git a/Makefile b/Makefile
+index b262c0a..7b5fb2f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -145,6 +145,8 @@ UPROGS=\
+ 	$U/_logstress\
+ 	$U/_forphan\
+ 	$U/_dorphan\
++	$U/_getcnt\
++
+ 
+ fs.img: mkfs/mkfs README $(UPROGS)
+ 	mkfs/mkfs fs.img README $(UPROGS)
+diff --git a/kernel/proc.c b/kernel/proc.c
+index 22a5401..45a35f6 100644
+--- a/kernel/proc.c
++++ b/kernel/proc.c
+@@ -688,3 +688,19 @@ procdump(void)
+     printf("\n");
+   }
+ }
++
++extern int syscall_counts[];
++
++uint64
++sys_getcnt(void)
++{
++  int target_sys_num;
++
++  argint(0, &target_sys_num);
++
++  if(target_sys_num <= 0 || target_sys_num >= 30) {
++    return -1;
++  }
++
++  return syscall_counts[target_sys_num];
++}
+\ No newline at end of file
+diff --git a/kernel/sysfile.c b/kernel/sysfile.c
+index a070e2d..f7762fe 100644
+--- a/kernel/sysfile.c
++++ b/kernel/sysfile.c
+@@ -504,21 +504,4 @@ sys_pipe(void)
+     return -1;
+   }
+   return 0;
+-}
+-
+-uint64
+-sys_getcnt(void)
+-{
+-  int target_sys_num;
+-  
+-  // argint(0, ...) pega o primeiro parâmetro passado para a syscall
+-  argint(0, &target_sys_num); 
+-
+-  // Validação de segurança para evitar acessos fora do array
+-  if(target_sys_num <= 0 || target_sys_num >= 30) {
+-    return -1; 
+-  }
+-
+-  // Retorna quantas vezes a syscall foi chamada
+-  return syscall_counts[target_sys_num];
+ }
+\ No newline at end of file
+diff --git a/user/user.h b/user/user.h
+index ac84de9..4a123f6 100644
+--- a/user/user.h
++++ b/user/user.h
+@@ -24,6 +24,7 @@ int getpid(void);
+ char* sys_sbrk(int,int);
+ int pause(int);
+ int uptime(void);
++int getcnt(int);
+ 
+ // ulib.c
+ int stat(const char*, struct stat*);
+diff --git a/user/usys.pl b/user/usys.pl
+index c5d4c3a..ac3d0eb 100755
+--- a/user/usys.pl
++++ b/user/usys.pl
+@@ -42,3 +42,4 @@ entry("getpid");
+ entry("sbrk");
+ entry("pause");
+ entry("uptime");
++entry("getcnt");
+\ No newline at end of file


### PR DESCRIPTION
Enviei com um erro na função exit() do proc.c que deve ser implementado pelo Estevão pois, na morte de um processo, o contador geral deve reduzir aqueles tickets e o processo deve ter seus tickets zerados. Além disso, criei o header pstat.h que deve complementar o syscall.