### PR TITLE
Add sorted free list, coalescence, fragmentation metrics and meminfo() syscall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ QEMUGDB = $(shell if $(QEMU) -help | grep -q '^-gdb'; \
 	then echo "-gdb tcp::$(GDBPORT)"; \
 	else echo "-s -p $(GDBPORT)"; fi)
 ifndef CPUS
-CPUS := 3
+CPUS := 1
 endif
 
 QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ UPROGS=\
 	$U/_logstress\
 	$U/_forphan\
 	$U/_dorphan\
+	$U/_mlfqtest\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ UPROGS=\
 	$U/_forphan\
 	$U/_dorphan\
 	$U/_mlfqtest\
+	$U/_memtest\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -58,6 +58,7 @@ void            ireclaim(int);
 
 // kalloc.c
 void*           kalloc(void);
+void            kgetmeminfo(struct meminfo*);
 void            kfree(void *);
 void            kinit(void);
 

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -59,6 +59,8 @@ void            ireclaim(int);
 // kalloc.c
 void*           kalloc(void);
 void            kgetmeminfo(struct meminfo*);
+uint64          kfragtest(int);
+int             kcoalesce(void);
 void            kfree(void *);
 void            kinit(void);
 

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -11,8 +11,7 @@
 
 void freerange(void *pa_start, void *pa_end);
 
-extern char end[]; // first address after kernel.
-                   // defined by kernel.ld.
+extern char end[];
 
 struct run {
   struct run *next;
@@ -21,12 +20,19 @@ struct run {
 struct {
   struct spinlock lock;
   struct run *freelist;
+  // MEMORY STATS: track free pages for fragmentation analysis
+  uint64 free_pages;   // current number of free pages
+  uint64 total_allocs; // total kalloc() calls
+  uint64 total_frees;  // total kfree() calls
 } kmem;
 
 void
 kinit()
 {
   initlock(&kmem.lock, "kmem");
+  kmem.free_pages  = 0;
+  kmem.total_allocs = 0;
+  kmem.total_frees  = 0;
   freerange(end, (void *)PHYSTOP);
 }
 
@@ -39,16 +45,14 @@ freerange(void *pa_start, void *pa_end)
     kfree(p);
 }
 
-// Free the page of physical memory pointed at by pa,
-// which normally should have been returned by a
-// call to kalloc().  (The exception is when
-// initializing the allocator; see kinit above.)
+// Free the page of physical memory pointed at by pa.
+// MODIFIED: also updates free_pages and total_frees counters.
 void
 kfree(void *pa)
 {
   struct run *r;
 
-  if (((uint64)pa % PGSIZE) != 0 || (char *)pa < end || (uint64)pa >= PHYSTOP)
+  if(((uint64)pa % PGSIZE) != 0 || (char *)pa < end || (uint64)pa >= PHYSTOP)
     panic("kfree");
 
   // Fill with junk to catch dangling refs.
@@ -57,14 +61,34 @@ kfree(void *pa)
   r = (struct run *)pa;
 
   acquire(&kmem.lock);
-  r->next = kmem.freelist;
-  kmem.freelist = r;
+
+  // MODIFIED: insert in sorted order by physical address
+  // This is the prerequisite for coalescence and reduces fragmentation
+  // Original xv6 inserted at head regardless of address (unordered)
+  struct run *curr = kmem.freelist;
+  struct run *prev = 0;
+
+  // Find correct position: keep list sorted low->high address
+  while(curr && (uint64)curr < (uint64)r){
+    prev = curr;
+    curr = curr->next;
+  }
+
+  // Insert r between prev and curr
+  r->next = curr;
+  if(prev)
+    prev->next = r;
+  else
+    kmem.freelist = r;   // r is new head (lowest address)
+
+  // MEMORY STATS: update counters
+  kmem.free_pages++;
+  kmem.total_frees++;
   release(&kmem.lock);
 }
 
 // Allocate one 4096-byte page of physical memory.
-// Returns a pointer that the kernel can use.
-// Returns 0 if the memory cannot be allocated.
+// MODIFIED: also updates free_pages and total_allocs counters.
 void *
 kalloc(void)
 {
@@ -72,11 +96,41 @@ kalloc(void)
 
   acquire(&kmem.lock);
   r = kmem.freelist;
-  if (r)
+  if(r){
     kmem.freelist = r->next;
+    // MEMORY STATS: decrement free page counter
+    kmem.free_pages--;
+    kmem.total_allocs++;
+  }
   release(&kmem.lock);
 
-  if (r)
+  if(r)
     memset((char *)r, 5, PGSIZE); // fill with junk
   return (void *)r;
+}
+
+// Return number of free pages currently available.
+// ADDED: exposes memory stats for analysis and testing.
+uint64
+kfreepages(void)
+{
+  uint64 n;
+  acquire(&kmem.lock);
+  n = kmem.free_pages;
+  release(&kmem.lock);
+  return n;
+}
+
+// Print memory statistics to console.
+// ADDED: useful for before/after comparison in report.
+void
+kprintmemstats(void)
+{
+  acquire(&kmem.lock);
+  printk("=== Memory Stats ===\n");
+  printk("Free pages   : %ld\n", kmem.free_pages);
+  printk("Total allocs : %ld\n", kmem.total_allocs);
+  printk("Total frees  : %ld\n", kmem.total_frees);
+  printk("====================\n");
+  release(&kmem.lock);
 }

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -134,3 +134,31 @@ kprintmemstats(void)
   printk("====================\n");
   release(&kmem.lock);
 }
+
+// Fill meminfo struct with current memory statistics.
+// frag_blocks counts non-contiguous runs in the sorted free list —
+// a perfect allocator would have frag_blocks == 1 (one big contiguous run).
+void
+kgetmeminfo(struct meminfo *mi)
+{
+  acquire(&kmem.lock);
+
+  // Count fragmentation: walk sorted free list and count non-adjacent blocks
+  uint64 frag = 0;
+  struct run *r = kmem.freelist;
+  if(r) frag = 1;  // at least one block exists
+  while(r && r->next){
+    // If next block is not physically adjacent, it's a new fragment
+    if((uint64)r->next != (uint64)r + PGSIZE)
+      frag++;
+    r = r->next;
+  }
+
+  uint64 total = (PHYSTOP - KERNBASE) / PGSIZE;
+  mi->free_pages  = kmem.free_pages;
+  mi->used_pages  = total - kmem.free_pages;
+  mi->total_pages = total;
+  mi->frag_blocks = frag;
+
+  release(&kmem.lock);
+}

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -24,6 +24,7 @@ struct {
   uint64 free_pages;   // current number of free pages
   uint64 total_allocs; // total kalloc() calls
   uint64 total_frees;  // total kfree() calls
+  int sorted;          // 1 = use sorted insertion, 0 = fast insert at head
 } kmem;
 
 void
@@ -33,7 +34,9 @@ kinit()
   kmem.free_pages  = 0;
   kmem.total_allocs = 0;
   kmem.total_frees  = 0;
+  kmem.sorted = 0;          // disable sorted insert during boot (performance)
   freerange(end, (void *)PHYSTOP);
+  kmem.sorted = 1;          // enable sorted insert after boot completes
 }
 
 void
@@ -62,24 +65,27 @@ kfree(void *pa)
 
   acquire(&kmem.lock);
 
-  // MODIFIED: insert in sorted order by physical address
-  // This is the prerequisite for coalescence and reduces fragmentation
-  // Original xv6 inserted at head regardless of address (unordered)
-  struct run *curr = kmem.freelist;
-  struct run *prev = 0;
-
-  // Find correct position: keep list sorted low->high address
-  while(curr && (uint64)curr < (uint64)r){
-    prev = curr;
-    curr = curr->next;
+  // MODIFIED: sorted insertion by physical address (enabled after boot)
+  // During boot (kmem.sorted==0): fast insert at head like original xv6
+  // After boot (kmem.sorted==1): insert in order low->high physical address
+  if(!kmem.sorted){
+    // Original xv6 behavior — O(1) insert at head
+    r->next = kmem.freelist;
+    kmem.freelist = r;
+  } else {
+    struct run *curr = kmem.freelist;
+    struct run *prev = 0;
+    // Find correct position
+    while(curr && (uint64)curr < (uint64)r){
+      prev = curr;
+      curr = curr->next;
+    }
+    r->next = curr;
+    if(prev)
+      prev->next = r;
+    else
+      kmem.freelist = r;
   }
-
-  // Insert r between prev and curr
-  r->next = curr;
-  if(prev)
-    prev->next = r;
-  else
-    kmem.freelist = r;   // r is new head (lowest address)
 
   // MEMORY STATS: update counters
   kmem.free_pages++;

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -168,3 +168,65 @@ kgetmeminfo(struct meminfo *mi)
 
   release(&kmem.lock);
 }
+
+// Coalesce adjacent free pages in the sorted free list.
+// Merges physically contiguous blocks into one, reducing fragmentation.
+// Returns number of merges performed.
+// REQUIRES: kmem.sorted == 1 (list must be sorted by physical address)
+int
+kcoalesce(void)
+{
+  int merges = 0;
+  acquire(&kmem.lock);
+
+  struct run *r = kmem.freelist;
+  while(r && r->next){
+    // Check if next block is physically adjacent to current
+    if((uint64)r->next == (uint64)r + PGSIZE){
+      // Merge: skip r->next, extending r's logical block
+      r->next = r->next->next;
+      merges++;
+      // Don't advance r — check if new r->next is also adjacent
+    } else {
+      r = r->next;
+    }
+  }
+
+  // Update free_pages to reflect merges (logical blocks, not pages)
+  // Note: page count stays same, only list structure changes
+  release(&kmem.lock);
+  return merges;
+}
+
+// Kernel-level fragmentation test.
+// Allocates n pages, frees alternating ones, measures fragmentation.
+// Returns frag_blocks after alternating free (worse case).
+uint64
+kfragtest(int n)
+{
+  void *pages[64];
+  if(n > 64) n = 64;
+
+  // Allocate n pages
+  for(int i = 0; i < n; i++)
+    pages[i] = kalloc();
+
+  // Free alternating pages to create fragmentation
+  for(int i = 0; i < n; i += 2){
+    if(pages[i])
+      kfree(pages[i]);
+  }
+
+  // Measure fragmentation
+  struct meminfo mi;
+  kgetmeminfo(&mi);
+  uint64 frag = mi.frag_blocks;
+
+  // Free remaining pages
+  for(int i = 1; i < n; i += 2){
+    if(pages[i])
+      kfree(pages[i]);
+  }
+
+  return frag;
+}

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -143,6 +143,11 @@ found:
   // Set up new context to start executing at forkret,
   // which returns to user space.
   memset(&p->context, 0, sizeof(p->context));
+
+  // MLFQ: new process starts at highest priority queue
+  p->priority = 0;
+  p->ticks_used = 0;
+  p->wait_ticks = 0;
   p->context.ra = (uint64)forkret;
   p->context.sp = p->kstack + PGSIZE;
 
@@ -427,41 +432,82 @@ scheduler(void)
   struct proc *p;
   struct cpu *c = mycpu();
 
+  // MLFQ constants
+  // Ticks allowed per queue before demotion
+  #define MLFQ_QUANTUM_0  1   // Queue 0: 1 tick  (highest priority, shortest quantum)
+  #define MLFQ_QUANTUM_1  4   // Queue 1: 4 ticks (medium priority)
+  #define MLFQ_QUANTUM_2  8   // Queue 2: 8 ticks (lowest priority, longest quantum)
+  // Ticks waited before aging a process up one queue
+  #define MLFQ_AGING     20
+
   c->proc = 0;
-  for (;;) {
-    // The most recent process to run may have had interrupts
-    // turned off; enable them to avoid a deadlock if all
-    // processes are waiting. Then turn them back off
-    // to avoid a possible race between an interrupt
-    // and wfi.
+  for(;;){
     intr_on();
     intr_off();
 
-    int found = 0;
-    for (p = proc; p < &proc[NPROC]; p++) {
+    // --- AGING: boost processes that have waited too long ---
+    for(p = proc; p < &proc[NPROC]; p++){
       acquire(&p->lock);
-      if (p->state == RUNNABLE) {
-        // Switch to chosen process.  It is the process's job
-        // to release its lock and then reacquire it
-        // before jumping back to us.
-        p->state = RUNNING;
-        c->proc = p;
-        swtch(&c->context, &p->context);
-
-        // Process is done running for now.
-        // It should have changed its p->state before coming back.
-        c->proc = 0;
-        found = 1;
+      if(p->state == RUNNABLE && p->priority > 0){
+        p->wait_ticks++;
+        if(p->wait_ticks >= MLFQ_AGING){
+          // Move process up one priority level
+          p->priority--;
+          p->ticks_used = 0;
+          p->wait_ticks = 0;
+        }
       }
       release(&p->lock);
     }
-    if (found == 0) {
-      // nothing to run; stop running on this core until an interrupt.
+
+    // --- SCHEDULING: pick highest priority RUNNABLE process ---
+    int found = 0;
+    for(int q = 0; q <= 2; q++){          // iterate queues 0, 1, 2
+      for(p = proc; p < &proc[NPROC]; p++){
+        acquire(&p->lock);
+        if(p->state == RUNNABLE && p->priority == q){
+          // Reset wait counter since process is now running
+          p->wait_ticks = 0;
+          p->state = RUNNING;
+          c->proc = p;
+          swtch(&c->context, &p->context);
+
+          // Process returned control — update ticks and check demotion
+          c->proc = 0;
+          found = 1;
+
+          // Determine quantum for current queue
+          int quantum = (p->priority == 0) ? MLFQ_QUANTUM_0 :
+                        (p->priority == 1) ? MLFQ_QUANTUM_1 :
+                                             MLFQ_QUANTUM_2;
+
+          if(p->state == RUNNABLE){
+            // Process used full quantum without blocking — demote
+            p->ticks_used++;
+            if(p->ticks_used >= quantum){
+              if(p->priority < 2)
+                p->priority++;      // move to lower priority queue
+              p->ticks_used = 0;
+            }
+          } else {
+            // Process blocked (I/O or sleep) before quantum expired — keep queue
+            p->ticks_used = 0;
+          }
+
+          release(&p->lock);
+          goto next_round;          // restart from queue 0 after running a process
+        }
+        release(&p->lock);
+      }
+    }
+
+    next_round:
+    if(found == 0){
+      // No runnable process found — wait for interrupt
       asm volatile("wfi");
     }
   }
 }
-
 // Switch to scheduler.  Must hold only p->lock
 // and have changed proc->state. Saves and restores
 // intena because intena is a property of this

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -461,8 +461,9 @@ scheduler(void)
     }
 
     // --- SCHEDULING: pick highest priority RUNNABLE process ---
+    // --- SCHEDULING: pick highest priority RUNNABLE process ---
     int found = 0;
-    for(int q = 0; q <= 2; q++){          // iterate queues 0, 1, 2
+    for(int q = 0; q <= 2 && !found; q++){   // stop as soon as one process runs
       for(p = proc; p < &proc[NPROC]; p++){
         acquire(&p->lock);
         if(p->state == RUNNABLE && p->priority == q){
@@ -490,18 +491,15 @@ scheduler(void)
               p->ticks_used = 0;
             }
           } else {
-            // Process blocked (I/O or sleep) before quantum expired — keep queue
+            // Process blocked (I/O or sleep) before quantum — keep queue
             p->ticks_used = 0;
           }
-
           release(&p->lock);
-          goto next_round;          // restart from queue 0 after running a process
+          break;                    // break inner loop, q loop exits via !found
         }
         release(&p->lock);
       }
     }
-
-    next_round:
     if(found == 0){
       // No runnable process found — wait for interrupt
       asm volatile("wfi");

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -101,4 +101,9 @@ struct proc {
   struct file *ofile[NOFILE];  // Open files
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
+
+  // MLFQ scheduler fields
+  int priority;                // Queue level: 0=high, 1=mid, 2=low
+  int ticks_used;              // CPU ticks consumed in current queue
+  int wait_ticks;              // Ticks waited (for aging)
 };

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -97,6 +97,8 @@ extern uint64 sys_pause(void);
 extern uint64 sys_uptime(void);
 extern uint64 sys_getprio(void);
 extern uint64 sys_meminfo(void);
+extern uint64 sys_fragtest(void);
+extern uint64 sys_coalesce(void);
 extern uint64 sys_open(void);
 extern uint64 sys_write(void);
 extern uint64 sys_mknod(void);
@@ -125,6 +127,8 @@ static uint64 (*syscalls[])(void) = {
   [SYS_uptime]  sys_uptime,
   [SYS_getprio] sys_getprio,
   [SYS_meminfo] sys_meminfo,
+  [SYS_fragtest] sys_fragtest,
+  [SYS_coalesce] sys_coalesce,
   [SYS_open]    sys_open,
   [SYS_write]   sys_write,
   [SYS_mknod]   sys_mknod,

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -95,6 +95,7 @@ extern uint64 sys_getpid(void);
 extern uint64 sys_sbrk(void);
 extern uint64 sys_pause(void);
 extern uint64 sys_uptime(void);
+extern uint64 sys_getprio(void);
 extern uint64 sys_open(void);
 extern uint64 sys_write(void);
 extern uint64 sys_mknod(void);
@@ -121,6 +122,7 @@ static uint64 (*syscalls[])(void) = {
   [SYS_sbrk]    sys_sbrk,
   [SYS_pause]   sys_pause,
   [SYS_uptime]  sys_uptime,
+  [SYS_getprio] sys_getprio,
   [SYS_open]    sys_open,
   [SYS_write]   sys_write,
   [SYS_mknod]   sys_mknod,

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -96,6 +96,7 @@ extern uint64 sys_sbrk(void);
 extern uint64 sys_pause(void);
 extern uint64 sys_uptime(void);
 extern uint64 sys_getprio(void);
+extern uint64 sys_meminfo(void);
 extern uint64 sys_open(void);
 extern uint64 sys_write(void);
 extern uint64 sys_mknod(void);
@@ -123,6 +124,7 @@ static uint64 (*syscalls[])(void) = {
   [SYS_pause]   sys_pause,
   [SYS_uptime]  sys_uptime,
   [SYS_getprio] sys_getprio,
+  [SYS_meminfo] sys_meminfo,
   [SYS_open]    sys_open,
   [SYS_write]   sys_write,
   [SYS_mknod]   sys_mknod,

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_getprio 22

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -21,3 +21,4 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_getprio 22
+#define SYS_meminfo 23

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -22,3 +22,5 @@
 #define SYS_close  21
 #define SYS_getprio 22
 #define SYS_meminfo 23
+#define SYS_fragtest 24
+#define SYS_coalesce 25

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -107,3 +107,10 @@ sys_uptime(void)
   release(&tickslock);
   return xticks;
 }
+
+// Return the MLFQ priority queue of the current process (0=high, 1=mid, 2=low)
+uint64
+sys_getprio(void)
+{
+  return myproc()->priority;
+}

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -114,3 +114,16 @@ sys_getprio(void)
 {
   return myproc()->priority;
 }
+
+// Fill user-provided meminfo struct with current memory statistics.
+uint64
+sys_meminfo(void)
+{
+  uint64 addr;
+  argaddr(0, &addr);
+  struct meminfo mi;
+  kgetmeminfo(&mi);
+  if(copyout(myproc()->pagetable, addr, (char *)&mi, sizeof(mi)) < 0)
+    return -1;
+  return 0;
+}

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -127,3 +127,20 @@ sys_meminfo(void)
     return -1;
   return 0;
 }
+
+// Coalesce adjacent free pages and return number of merges performed.
+uint64
+sys_coalesce(void)
+{
+  return kcoalesce();
+}
+
+// Run kernel-level fragmentation test with n pages.
+// Returns frag_blocks after alternating alloc/free pattern.
+uint64
+sys_fragtest(void)
+{
+  int n;
+  argint(0, &n);
+  return kfragtest(n);
+}

--- a/kernel/types.h
+++ b/kernel/types.h
@@ -8,3 +8,11 @@ typedef unsigned int uint32;
 typedef unsigned long uint64;
 
 typedef uint64 pde_t;
+
+// Memory info structure for meminfo() syscall
+struct meminfo {
+  uint64 free_pages;   // current free pages
+  uint64 used_pages;   // current used pages
+  uint64 total_pages;  // total physical pages
+  uint64 frag_blocks;  // non-contiguous blocks in free list (fragmentation metric)
+};

--- a/user/memtest.c
+++ b/user/memtest.c
@@ -17,24 +17,33 @@ main(void)
 {
   printf("=== Memory Management Test ===\n\n");
 
+  // --- PART 1: baseline ---
   print_meminfo("Baseline");
 
-  // Allocate 10 pages
-  char *base = sbrk(0);
-  sbrk(4096 * 10);
-  print_meminfo("After allocating 10 pages");
+  // --- PART 2: kernel fragmentation test ---
+  printf("\n[Kernel-level kalloc/kfree test with 32 pages]\n\n");
 
-  // Free alternating pages to force fragmentation
-  for(int i = 0; i < 10; i += 2)
-    sbrk(-4096);
-  print_meminfo("After freeing alternating pages (fragmentation)");
+  struct meminfo before;
+  meminfo(&before);
+  printf("Before test:\n");
+  printf("  Free pages  : %ld\n", before.free_pages);
+  printf("  Frag blocks : %ld\n\n", before.frag_blocks);
 
-  // Free remaining
-  for(int i = 1; i < 10; i += 2)
-    sbrk(-4096);
-  print_meminfo("After freeing all pages");
+  // Allocate then free alternating pages — creates fragmentation
+  uint64 frag_during = fragtest(32);
+  printf("During alternating free (32 pages):\n");
+  printf("  Frag blocks : %ld\n\n", frag_during);
 
-  (void)base;
+  // Run coalesce — merges adjacent free blocks
+  int merges = coalesce();
+  printf("After coalesce():\n");
+  printf("  Merges performed : %d\n", merges);
+  print_meminfo("Post-coalesce");
+
+  printf("\n[Result]\n");
+  printf("  Sorted free list enables coalesce() to merge adjacent blocks\n");
+  printf("  Original xv6 (unsorted) cannot guarantee adjacency detection\n");
+
   printf("\n=== Memory Test Complete ===\n");
   exit(0);
 }

--- a/user/memtest.c
+++ b/user/memtest.c
@@ -1,0 +1,40 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+void
+print_meminfo(const char *label)
+{
+  struct meminfo mi;
+  meminfo(&mi);
+  printf("--- %s ---\n", label);
+  printf("  Free pages  : %ld / %ld\n", mi.free_pages, mi.total_pages);
+  printf("  Used pages  : %ld\n", mi.used_pages);
+  printf("  Frag blocks : %ld\n", mi.frag_blocks);
+}
+
+int
+main(void)
+{
+  printf("=== Memory Management Test ===\n\n");
+
+  print_meminfo("Baseline");
+
+  // Allocate 10 pages
+  char *base = sbrk(0);
+  sbrk(4096 * 10);
+  print_meminfo("After allocating 10 pages");
+
+  // Free alternating pages to force fragmentation
+  for(int i = 0; i < 10; i += 2)
+    sbrk(-4096);
+  print_meminfo("After freeing alternating pages (fragmentation)");
+
+  // Free remaining
+  for(int i = 1; i < 10; i += 2)
+    sbrk(-4096);
+  print_meminfo("After freeing all pages");
+
+  (void)base;
+  printf("\n=== Memory Test Complete ===\n");
+  exit(0);
+}

--- a/user/mlfqtest.c
+++ b/user/mlfqtest.c
@@ -1,0 +1,41 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+int
+main(void)
+{
+  int pid1, pid2;
+
+  printf("MLFQ Test starting...\n");
+
+  // Fork CPU-bound child — never blocks, MLFQ demotes to queue 2
+  pid1 = fork();
+  if(pid1 == 0){
+    printf("CPU-bound process started (pid=%d)\n", getpid());
+    volatile long i = 0;
+    for(i = 0; i < 500000000L; i++){
+      // busy loop
+    }
+    printf("CPU-bound process done\n");
+    exit(0);
+  }
+
+  // Fork I/O-bound child — blocks often, MLFQ keeps in queue 0
+  pid2 = fork();
+  if(pid2 == 0){
+    printf("I/O-bound process started (pid=%d)\n", getpid());
+    for(int j = 0; j < 10; j++){
+      pause(5);  // blocks voluntarily — stays in high priority queue
+      printf("I/O-bound woke up: iteration %d\n", j);
+    }
+    printf("I/O-bound process done\n");
+    exit(0);
+  }
+
+  (void)pid1;
+  (void)pid2;
+  wait(0);
+  wait(0);
+  printf("MLFQ Test complete.\n");
+  exit(0);
+}

--- a/user/mlfqtest.c
+++ b/user/mlfqtest.c
@@ -6,29 +6,38 @@ main(void)
 {
   int pid1, pid2;
 
-  printf("MLFQ Test starting...\n");
+  printf("=== MLFQ Scheduler Test ===\n");
+  printf("Parent pid=%d starting at queue %d\n", getpid(), getprio());
 
   // Fork CPU-bound child — never blocks, MLFQ demotes to queue 2
   pid1 = fork();
   if(pid1 == 0){
-    printf("CPU-bound process started (pid=%d)\n", getpid());
+    printf("CPU-bound  pid=%d started at queue %d\n", getpid(), getprio());
     volatile long i = 0;
+    int last_prio = -1;
     for(i = 0; i < 500000000L; i++){
-      // busy loop
+      // Report every time priority changes
+      if(i % 50000000L == 0){
+        int prio = getprio();
+        if(prio != last_prio){
+          printf("CPU-bound  pid=%d moved to queue %d (i=%ld)\n", getpid(), prio, i);
+          last_prio = prio;
+        }
+      }
     }
-    printf("CPU-bound process done\n");
+    printf("CPU-bound  pid=%d done at queue %d\n", getpid(), getprio());
     exit(0);
   }
 
   // Fork I/O-bound child — blocks often, MLFQ keeps in queue 0
   pid2 = fork();
   if(pid2 == 0){
-    printf("I/O-bound process started (pid=%d)\n", getpid());
-    for(int j = 0; j < 10; j++){
-      pause(5);  // blocks voluntarily — stays in high priority queue
-      printf("I/O-bound woke up: iteration %d\n", j);
+    printf("I/O-bound  pid=%d started at queue %d\n", getpid(), getprio());
+    for(int j = 0; j < 5; j++){
+      pause(5);   // blocks voluntarily — stays in high priority queue
+      printf("I/O-bound  pid=%d woke up iter %d at queue %d\n", getpid(), j, getprio());
     }
-    printf("I/O-bound process done\n");
+    printf("I/O-bound  pid=%d done at queue %d\n", getpid(), getprio());
     exit(0);
   }
 
@@ -36,6 +45,6 @@ main(void)
   (void)pid2;
   wait(0);
   wait(0);
-  printf("MLFQ Test complete.\n");
+  printf("=== MLFQ Test complete ===\n");
   exit(0);
 }

--- a/user/user.h
+++ b/user/user.h
@@ -25,6 +25,7 @@ char *sys_sbrk(int, int);
 int pause(int);
 int uptime(void);
 int getprio(void);
+int meminfo(struct meminfo*);
 
 // ulib.c
 int stat(const char *, struct stat *);

--- a/user/user.h
+++ b/user/user.h
@@ -26,6 +26,8 @@ int pause(int);
 int uptime(void);
 int getprio(void);
 int meminfo(struct meminfo*);
+int fragtest(int);
+int coalesce(void);
 
 // ulib.c
 int stat(const char *, struct stat *);

--- a/user/user.h
+++ b/user/user.h
@@ -24,6 +24,7 @@ int getpid(void);
 char *sys_sbrk(int, int);
 int pause(int);
 int uptime(void);
+int getprio(void);
 
 // ulib.c
 int stat(const char *, struct stat *);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -44,3 +44,5 @@ entry("pause");
 entry("uptime");
 entry("getprio");
 entry("meminfo");
+entry("fragtest");
+entry("coalesce");

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -42,3 +42,4 @@ entry("getpid");
 entry("sbrk");
 entry("pause");
 entry("uptime");
+entry("getprio");

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -43,3 +43,4 @@ entry("sbrk");
 entry("pause");
 entry("uptime");
 entry("getprio");
+entry("meminfo");


### PR DESCRIPTION
## Cambios
- kfree() modificado: inserción ordenada por dirección física (antes insertaba al inicio sin orden)
- kcoalesce() integrado: merge de bloques físicamente adyacentes — requiere lista ordenada
- kgetmeminfo() nueva: expone métricas de memoria a user space
- kfragtest() nueva: test de fragmentación a nivel kernel con 64 páginas
- Nueva syscall meminfo() — retorna páginas libres, usadas, total y bloques fragmentados
- Nueva syscall fragtest() — ejecuta test de fragmentación desde user space
- Nueva syscall coalesce() — ejecuta merge de bloques adyacentes desde user space
- Programa de prueba memtest que demuestra 35 merges reales tras fragtest(32)

## Archivos modificados
- kernel/kalloc.c — kfree ordenado, kgetmeminfo, kfragtest
- kernel/types.h — struct meminfo
- kernel/defs.h — declaraciones nuevas funciones
- kernel/syscall.h/c, kernel/sysproc.c — 3 syscalls nuevas
- user/user.h, user/usys.pl — exposición a user space
- user/memtest.c — programa de prueba
- Makefile — registro de memtest