### PR TITLE
pipe: return -1 on first-byte copyin failure

### DIFF
--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -90,8 +90,11 @@ pipewrite(struct pipe *pi, uint64 addr, int n)
       sleep(&pi->nwrite, &pi->lock);
     } else {
       char ch;
-      if (copyin(pr->pagetable, &ch, addr + i, 1) == -1)
+      if(copyin(pr->pagetable, &ch, addr + i, 1) == -1) {
+        if(i == 0)
+          i = -1;
         break;
+      }
       pi->data[pi->nwrite++ % PIPESIZE] = ch;
       i++;
     }


### PR DESCRIPTION
### pipe: return -1 on first-byte copyin failure

#### Summary

This fix corrects the return behavior of `pipewrite()` when the first `copyin()` from user memory fails.

Previously, if `copyin()` failed on the first byte, `pipewrite()` would break out of the loop with `i == 0` and incorrectly return `0`, making the syscall appear as a successful zero-byte write instead of an error.

#### Fix

The behavior has been aligned with `piperead()`.

Now, if the first `copyin()` fails before any bytes are written, `pipewrite()` returns `-1`:

```c
if (copyin(pr->pagetable, &ch, addr + i, 1) == -1) {
  if (i == 0)
    i = -1;
  break;
}
```

#### Verification

* Reproduced the issue using a user program passing an invalid pointer (`(char*)-1`) to `write()` on a pipe.
* Before fix: return value was `0`
* After fix: return value is `-1`

#### Result

This ensures consistent error handling between `pipewrite()` and `piperead()` for first-byte memory access failures.

Closes #516 

