### PR TITLE
fix: sys_read accepts negative lengths

### DIFF
--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -74,6 +74,10 @@ sys_read(void)
 
   argaddr(1, &p);
   argint(2, &n);
+
+  if(n < 0)
+    return -1;
+
   if (argfd(0, 0, &f) < 0)
     return -1;
   return fileread(f, p, n);


### PR DESCRIPTION
### sys_read: reject negative read lengths

#### Summary

`sys_read()` currently forwards the user-supplied length argument directly to `fileread()` without validating whether it is negative.

For regular files, this value is eventually passed to `readi()`, whose length parameter is unsigned. As a result, a negative length can be interpreted as a very large unsigned value and subsequently clamped to the file size, causing `read()` to succeed instead of reporting an error.

#### Fix

Add validation in `sys_read()` to reject negative lengths before calling `fileread()`:

```c
if (n < 0)
  return -1;
```

#### Verification

I reproduced the issue using a user program that:

1. Creates a small file.
2. Calls `read(fd, buf, -1)`.
3. Checks the return value.

Before this change:

* `read(fd, buf, -1)` returned a non-negative value and successfully read file data.

After this change:

* `read(fd, buf, -1)` correctly returns `-1`.

This ensures invalid negative read lengths are rejected at the syscall boundary before reaching the filesystem layer.

Closes #515 
