### PR TITLE
vm: fault in lazily-allocated pages in copyinstr()

### DIFF
--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -417,8 +417,11 @@ copyinstr(pagetable_t pagetable, char *dst, uint64 srcva, uint64 max)
   while (got_null == 0 && max > 0) {
     va0 = PGROUNDDOWN(srcva);
     pa0 = walkaddr(pagetable, va0);
-    if (pa0 == 0)
-      return -1;
+    if (pa0 == 0) {
+      if ((pa0 = vmfault(pagetable, va0, 1)) == 0) {
+        return -1;
+      }
+    }
     n = PGSIZE - (srcva - va0);
     if (n > max)
       n = max;


### PR DESCRIPTION
## Summary

Fixes #514.

`copyinstr()` returned `-1` immediately when `walkaddr()` found no mapping
for a user page, unlike its sibling functions `copyin()` and `copyout()`,
which call `vmfault()` to materialize lazily-allocated pages on demand.

This inconsistency meant that any syscall taking a string argument — routed
through `argstr()` / `fetchstr()` and ultimately `copyinstr()` — would fail
when the string lived in a page that had been lazily allocated but not yet
faulted in, even though the memory was perfectly valid.

## Change

In `copyinstr()`, when `walkaddr()` returns 0, attempt to fault the page in
via `vmfault()` before giving up, mirroring the existing logic in `copyin()`