### PR TITLE
Chore print add binary formatting 00

### DIFF
--- a/kernel/printk.c
+++ b/kernel/printk.c
@@ -107,6 +107,14 @@ printk(char *fmt, ...)
     } else if (c0 == 'l' && c1 == 'l' && c2 == 'x') {
       printint(va_arg(ap, uint64), 16, 0);
       i += 2;
+    } else if (c0 == 'b') {
+      printint(va_arg(ap, uint32), 2, 0);
+    } else if (c0 == 'l' && c1 == 'b') {
+      printint(va_arg(ap, uint64), 2, 0);
+      i += 1;
+    } else if (c0 == 'l' && c1 == 'l' && c2 == 'b') {
+      printint(va_arg(ap, uint64), 2, 0);
+      i += 2;
     } else if (c0 == 'p') {
       printptr(va_arg(ap, uint64));
     } else if (c0 == 'c') {

--- a/user/printf.c
+++ b/user/printf.c
@@ -48,7 +48,7 @@ printptr(int fd, uint64 x)
     putc(fd, digits[x >> (sizeof(uint64) * 8 - 4)]);
 }
 
-// Print to the given fd. Only understands %d, %x, %p, %c, %s.
+// Print to the given fd. Only understands %d, %x, %b, %p, %c, %s.
 void
 vprintf(int fd, const char *fmt, va_list ap)
 {
@@ -93,6 +93,14 @@ vprintf(int fd, const char *fmt, va_list ap)
         i += 1;
       } else if (c0 == 'l' && c1 == 'l' && c2 == 'x') {
         printint(fd, va_arg(ap, uint64), 16, 0);
+        i += 2;
+      } else if (c0 == 'b') {
+        printint(fd, va_arg(ap, uint32), 2, 0);
+      } else if (c0 == 'l' && c1 == 'b') {
+        printint(fd, va_arg(ap, uint64), 2, 0);
+        i += 1;
+      } else if (c0 == 'l' && c1 == 'l' && c2 == 'b') {
+        printint(fd, va_arg(ap, uint64), 2, 0);
         i += 2;
       } else if (c0 == 'p') {
         printptr(fd, va_arg(ap, uint64));


### PR DESCRIPTION
## Description

Add an option to print in binary for kernel (`printk`) and user space (`printf`)

## Testing

<details>

`printk` in kernel/main.c

<img width="542" height="423" alt="image" src="https://github.com/user-attachments/assets/d5651a32-5662-46d2-830d-f9b78ebe36d4" />


`printf` in user/init.c

<img width="542" height="423" alt="image" src="https://github.com/user-attachments/assets/e922e94b-d5fc-4080-b28d-392600a66fc9" />


output 

<img width="306" height="582" alt="image" src="https://github.com/user-attachments/assets/d37eb536-e5d0-4053-9394-cc3ca6030f2a" />


</details>