### PR TITLE
vm: map lazily-allocated pages in the caller's pagetable

### DIFF
--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -467,7 +467,7 @@ vmfault(pagetable_t pagetable, uint64 va, int read)
   if (mem == 0)
     return 0;
   memset((void *)mem, 0, PGSIZE);
-  if (mappages(p->pagetable, va, PGSIZE, mem, PTE_W | PTE_U | PTE_R) != 0) {
+  if (mappages(pagetable, va, PGSIZE, mem, PTE_W | PTE_U | PTE_R) != 0) {
     kfree((void *)mem);
     return 0;
   }


### PR DESCRIPTION
Fixes #526.

`vmfault()` validates against its `pagetable` argument via `ismapped()`, but installs the mapping with `mappages(p->pagetable, ...)`. This makes the function use the supplied page table in both places.

No current caller reaches `vmfault()` with a page table other than `p->pagetable`, `kexec()` is the only one that passes a different table to `copyout()`, and it eagerly allocates the user stack so `walkaddr()` never fails there. So this is a consistency fix for a latent issue, not a fix for an observed crash.

Tested on the `riscv` branch with `riscv64-elf-gcc` 16.1.0 and qemu 11.0.3: builds clean and `usertests` reports `ALL TESTS PASSED`, both before and after the change.