### PR TITLE
  fix usertests build -Werror build failure with newer GCC on macOS

### DIFF
--- a/user/usertests.c
+++ b/user/usertests.c
@@ -2349,7 +2349,7 @@ void
 fsfull()
 {
   int nfiles;
-  int fsblocks = 0;
+  int fsblocks __attribute__((unused)) = 0;
 
   printf("fsfull test\n");
 

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -2349,7 +2349,6 @@ void
 fsfull()
 {
   int nfiles;
-  int fsblocks __attribute__((unused)) = 0;
 
   printf("fsfull test\n");
 
@@ -2373,7 +2372,6 @@ fsfull()
       if (cc < BSIZE)
         break;
       total += cc;
-      fsblocks++;
     }
     printf("wrote %d bytes\n", total);
     close(fd);


### PR DESCRIPTION
  GCC 13+ (shipped via Homebrew riscv64-elf-gcc) enables
  -Wunused-but-set-variable by default. Combined with -Werror in the
  Makefile, this breaks the build on `fsblocks` in fsfull() which is
  incremented but never read.


Failure output:

```
% make qemu
riscv64-elf-gcc -Wall -Werror -Wno-unknown-attributes -O -fno-omit-frame-pointer -ggdb -gdwarf-2 -march=rv64gc -std=gnu99 -MD -mcmodel=medany -ffreestanding -fno-common -nostdlib -fno-builtin-strncpy -fno-builtin-strncmp -fno-builtin-strlen -fno-builtin-memset -fno-builtin-memmove -fno-builtin-memcmp -fno-builtin-log -fno-builtin-bzero -fno-builtin-strchr -fno-builtin-exit -fno-builtin-malloc -fno-builtin-putc -fno-builtin-free -fno-builtin-memcpy -Wno-main -fno-builtin-printf -fno-builtin-fprintf -fno-builtin-vprintf -I. -fno-stack-protector -fno-pie -no-pie   -c -o user/usertests.o user/usertests.c
user/usertests.c: In function 'fsfull':
user/usertests.c:2352:7: error: variable 'fsblocks' set but not used [-Werror=unused-but-set-variable=]
 2352 |   int fsblocks = 0;
      |       ^~~~~~~~
At top level:
cc1: note: unrecognized command-line option '-Wno-unknown-attributes' may have been intended to silence earlier diagnostics
cc1: all warnings being treated as errors
make: *** [user/usertests.o] Error 1

```


My local environment:

```
$qemu-system-riscv64 --version
QEMU emulator version 11.0.3
Copyright (c) 2003-2026 Fabrice Bellard and the QEMU Project developers

$ riscv64-elf-gcc --version
riscv64-elf-gcc (GCC) 16.1.0


$ make --version 
GNU Make 3.81
This program built for i386-apple-darwin11.3.0

$ sw_vers
ProductName:            macOS
ProductVersion:         26.5.2
BuildVersion:           25F84
```


Possible solution:
1. remove not used local counter fsblocks,
2. mark  fsblocks as `__attribute__((unused))`

Issue: https://github.com/mit-pdos/xv6-riscv/issues/529
