### PR TITLE
docs: unify kernel pagetable comment style

### DIFF
--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -52,7 +52,7 @@ kvmmake(void)
   return kpgtbl;
 }
 
-// add a mapping to the kernel page table.
+// add a mapping to the kernel's page table.
 // only used when booting.
 // does not flush TLB or enable paging.
 void
@@ -62,7 +62,7 @@ kvmmap(pagetable_t kpgtbl, uint64 va, uint64 pa, uint64 sz, int perm)
     panic("kvmmap");
 }
 
-// Initialize the kernel_pagetable, shared by all CPUs.
+// Initialize the kernel's pagetable, shared by all CPUs.
 void
 kvminit(void)
 {


### PR DESCRIPTION
Align comments of `kvmmap/kvminit/kvminithart` to the global kernel_pagetable comment style