### PR TITLE
Fix an outdated C standard description in README

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 xv6 is a re-implementation of Dennis Ritchie's and Ken Thompson's Unix
 Version 6 (v6).  xv6 loosely follows the structure and style of v6,
-but is implemented for a modern RISC-V multiprocessor using ANSI C.
+but is implemented for a modern RISC-V multiprocessor using C99 with
+GNU extensions.
 
 ACKNOWLEDGMENTS
 


### PR DESCRIPTION
The README currently states that xv6 is implemented using **`ANSI C`**. However, since commit 7f5dfd3, the Makefile explicitly mandates `-std=gnu99`. This commit updates the text to **`C99 with GNU extensions`** to accurately reflect the actual compilation flags and codebase characteristics.