### PR TITLE
test-xv6.py: fix three bugs on the failure path

### DIFF
--- a/test-xv6.py
+++ b/test-xv6.py
@@ -46,7 +46,7 @@ class QEMU(object):
     def save_output(self):
       try:
         with open("test-xv6.out", "w") as f:
-            f.write(self.out)
+            f.write(self.output)
             f.close()
       except OSError as e:
         print("Provided a bad results path. Error:", e)     

--- a/test-xv6.py
+++ b/test-xv6.py
@@ -77,7 +77,7 @@ class QEMU(object):
     def lines(self):
         return self.output.splitlines()
 
-    def error(self):
+    def error(self, *regexps):
         print("FAIL: match failed", regexps)
         self.save_output()
         self.stop()
@@ -91,7 +91,7 @@ class QEMU(object):
                 print(line)
                 last = i
         if last == -1 and exit:
-            self.error()
+            self.error(*regexps)
         l = ""
         if last >= 0:
             l = lines[last]
@@ -103,7 +103,7 @@ class QEMU(object):
             time.sleep(1)
             timeleft = deadline - time.time()
             if timeleft < 0:
-                self.error()
+                self.error(*regexps)
             self.read()
             ok, _ = self.match(*regexps, exit=False)
             if ok:

--- a/test-xv6.py
+++ b/test-xv6.py
@@ -62,7 +62,7 @@ class QEMU(object):
         kids = [int(line) for line in ps.stdout.splitlines()]
         if len(kids) == 0:
             print("no qemu")
-            os.exit(1)
+            sys.exit(1)
         print("kill", kids[0])
         os.kill(kids[0], signal.SIGKILL)
 


### PR DESCRIPTION
`test-xv6.py`'s failure path raises a Python exception instead of reporting the
failure, so a failing test destroys the diagnostics the script was in the middle
of producing. The bugs are unreachable as long as every test passes.

### 1. `error()` cannot print the patterns it failed to match

It takes no arguments but prints a name `regexps` that exists neither as a
parameter nor as a global. It raises `NameError` on its first statement
before `save_output()` and `stop()` run and therefore neither the transcript nor the QEMU
teardown happens. Both call sites, `match()` and `monitor()`, have the patterns
in hand and now forward them.

### 2. `crash()` exits through a function that does not exist

When `ps` reports no child process it calls `os.exit(1)`, which raises
`AttributeError` instead of exiting. `sys` is already imported, and `sys.exit()`
is what `error()` and `test_log()` already use.

### 3. `save_output()` writes an attribute that is never assigned

It writes `self.out`, but the transcript is in `self.output`, set in `__init__`
and refreshed by `read()`. `except OSError` does not catch the resulting
`AttributeError`, so `test-xv6.out` is left empty.

### Testing

Point a match at output that will never appear:

```console
$ sed -i "s/q.match('wait')/q.match('^NO SUCH OUTPUT')/" test-xv6.py
$ ./test-xv6.py forphan        # revert with: git checkout test-xv6.py
```

**Before:** a `NameError` traceback, no `test-xv6.out`, and qemu left running as
an orphan.

**After:** `FAIL: match failed ('^NO SUCH OUTPUT',)`, the captured console output
written to `test-xv6.out`, qemu terminated, exit status 1.

The `crash()` path was checked the same way, by pointing `ps` at a pid with no
children: it now prints `no qemu` and exits 1 rather than raising.

`./test-xv6.py -q usertests` still ends in `ALL TESTS PASSED`
The success path never enters any of the three functions.
