### PR TITLE
Run xv6 on rv64ia_zicsr_zifencei

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/softdiv.o
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -61,7 +62,7 @@ OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
 CFLAGS = -Wall -Werror -Wno-unknown-attributes -O -fno-omit-frame-pointer -ggdb -gdwarf-2
-CFLAGS += -march=rv64gc
+CFLAGS += -march=rv64ia_zicsr_zifencei -mabi=lp64
 CFLAGS += -std=gnu99
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
@@ -92,12 +93,12 @@ $K/kernel: $(OBJS) $K/kernel.ld
 	$(OBJDUMP) -t $K/kernel | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $K/kernel.sym
 
 $K/%.o: $K/%.S
-	$(CC) -march=rv64gc -g -c -o $@ $<
+	$(CC) -march=rv64ia_zicsr_zifencei -mabi=lp64 -g -c -o $@ $<
 
 tags: $(OBJS)
 	etags kernel/*.S kernel/*.c
 
-ULIB = $U/ulib.o $U/usys.o $U/printf.o $U/umalloc.o
+ULIB = $U/softdiv.o $U/ulib.o $U/usys.o $U/printf.o $U/umalloc.o
 
 _%: %.o $(ULIB) $U/user.ld
 	$(LD) $(LDFLAGS) -T $U/user.ld -o $@ $< $(ULIB)

--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -9,12 +9,13 @@ _entry:
         # stack0 is declared in start.c,
         # with a 4096-byte stack per CPU.
         # sp = stack0 + ((hartid + 1) * 4096)
+        # 4096 = 2^12: multiply-by-constant is a shift.
+        # No M extension needed -- and still correct for ANY hart count.
         la sp, stack0
-        li a0, 1024*4
         csrr a1, mhartid
         addi a1, a1, 1
-        mul a0, a0, a1
-        add sp, sp, a0
+        slli a1, a1, 12
+        add sp, sp, a1
         # jump to start() in start.c
         call start
 spin:

--- a/kernel/softdiv.c
+++ b/kernel/softdiv.c
@@ -1,0 +1,85 @@
+// Software integer multiply / divide / remainder for RV64I (no M extension).
+//
+// When compiled with -march=rv64ia... (no 'm'), gcc lowers C's * / % on
+// variables into calls to these libgcc routines. The system libgcc.a is
+// built for the lp64d ABI and won't link against lp64 objects, so we
+// provide freestanding replacements.
+//
+// CAREFUL: inside these functions we must not use * / % on variables --
+// gcc would compile them into calls to these very functions (recursion).
+// Everything is shift-and-add / shift-and-subtract.
+//
+// Division semantics follow the RISC-V M spec:
+//   x / 0 == all-ones quotient, x % 0 == x.
+
+typedef unsigned long u64;
+typedef long i64;
+
+// one pass of binary long division: returns quotient, stores remainder.
+static u64
+udivmod(u64 n, u64 d, u64 *rem)
+{
+  u64 q = 0, r = 0;
+  int i;
+
+  if(d == 0){
+    if(rem) *rem = n;      // RISC-V: rem of div-by-zero is the dividend
+    return ~0UL;           // quotient: all ones
+  }
+  for(i = 63; i >= 0; i--){
+    r = (r << 1) | ((n >> i) & 1);
+    if(r >= d){
+      r -= d;
+      q |= (1UL << i);
+    }
+  }
+  if(rem) *rem = r;
+  return q;
+}
+
+u64
+__udivdi3(u64 n, u64 d)
+{
+  return udivmod(n, d, 0);
+}
+
+u64
+__umoddi3(u64 n, u64 d)
+{
+  u64 r;
+  udivmod(n, d, &r);
+  return r;
+}
+
+i64
+__divdi3(i64 n, i64 d)
+{
+  u64 un = n < 0 ? -(u64)n : (u64)n;
+  u64 ud = d < 0 ? -(u64)d : (u64)d;
+  u64 q = udivmod(un, ud, 0);
+  return ((n < 0) != (d < 0) && d != 0) ? -(i64)q : (i64)q;
+}
+
+i64
+__moddi3(i64 n, i64 d)
+{
+  u64 un = n < 0 ? -(u64)n : (u64)n;
+  u64 ud = d < 0 ? -(u64)d : (u64)d;
+  u64 r;
+  udivmod(un, ud, &r);
+  return n < 0 ? -(i64)r : (i64)r;   // remainder takes dividend's sign
+}
+
+// shift-and-add multiply; correct mod 2^64 for signed too (two's complement).
+u64
+__muldi3(u64 a, u64 b)
+{
+  u64 r = 0;
+  while(b){
+    if(b & 1)
+      r += a;
+    a <<= 1;
+    b >>= 1;
+  }
+  return r;
+}

--- a/user/softdiv.c
+++ b/user/softdiv.c
@@ -1,0 +1,85 @@
+// Software integer multiply / divide / remainder for RV64I (no M extension).
+//
+// When compiled with -march=rv64ia... (no 'm'), gcc lowers C's * / % on
+// variables into calls to these libgcc routines. The system libgcc.a is
+// built for the lp64d ABI and won't link against lp64 objects, so we
+// provide freestanding replacements.
+//
+// CAREFUL: inside these functions we must not use * / % on variables --
+// gcc would compile them into calls to these very functions (recursion).
+// Everything is shift-and-add / shift-and-subtract.
+//
+// Division semantics follow the RISC-V M spec:
+//   x / 0 == all-ones quotient, x % 0 == x.
+
+typedef unsigned long u64;
+typedef long i64;
+
+// one pass of binary long division: returns quotient, stores remainder.
+static u64
+udivmod(u64 n, u64 d, u64 *rem)
+{
+  u64 q = 0, r = 0;
+  int i;
+
+  if(d == 0){
+    if(rem) *rem = n;      // RISC-V: rem of div-by-zero is the dividend
+    return ~0UL;           // quotient: all ones
+  }
+  for(i = 63; i >= 0; i--){
+    r = (r << 1) | ((n >> i) & 1);
+    if(r >= d){
+      r -= d;
+      q |= (1UL << i);
+    }
+  }
+  if(rem) *rem = r;
+  return q;
+}
+
+u64
+__udivdi3(u64 n, u64 d)
+{
+  return udivmod(n, d, 0);
+}
+
+u64
+__umoddi3(u64 n, u64 d)
+{
+  u64 r;
+  udivmod(n, d, &r);
+  return r;
+}
+
+i64
+__divdi3(i64 n, i64 d)
+{
+  u64 un = n < 0 ? -(u64)n : (u64)n;
+  u64 ud = d < 0 ? -(u64)d : (u64)d;
+  u64 q = udivmod(un, ud, 0);
+  return ((n < 0) != (d < 0) && d != 0) ? -(i64)q : (i64)q;
+}
+
+i64
+__moddi3(i64 n, i64 d)
+{
+  u64 un = n < 0 ? -(u64)n : (u64)n;
+  u64 ud = d < 0 ? -(u64)d : (u64)d;
+  u64 r;
+  udivmod(un, ud, &r);
+  return n < 0 ? -(i64)r : (i64)r;   // remainder takes dividend's sign
+}
+
+// shift-and-add multiply; correct mod 2^64 for signed too (two's complement).
+u64
+__muldi3(u64 a, u64 b)
+{
+  u64 r = 0;
+  while(b){
+    if(b & 1)
+      r += a;
+    a <<= 1;
+    b >>= 1;
+  }
+  return r;
+}


### PR DESCRIPTION
In order to run xv6 on a minimal profile FPGA implementation, I need to patch xv6 a bit.
