### PR TITLE
add pingpong exercise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,8 @@ UPROGS=\
 	$U/_forphan\
 	$U/_dorphan\
 	$U/_sync\
+	$U/_pingpong\
+	$U/_pingpongmsg\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/user/pingpong.c
+++ b/user/pingpong.c
@@ -1,0 +1,50 @@
+#include "kernel/types.h"
+#include "user.h"
+#include "printf.h"
+
+int main(int argc, char *argv[])
+{
+	int ping[2];
+  int pong[2];
+  (void)pipe(ping);
+  (void)pipe(pong);
+
+  uint64 start = uptime();
+  uint64 pingpongs;
+
+  if (argc < 2) {
+    pingpongs = 10000000;
+  } else {
+    pingpongs = (uint64)atoi(argv[1]);
+  }
+
+  char b = 0x41; // A
+  char buf;
+  int stdout = 1;
+
+	int pid = fork();
+
+  if (pid > 0) {
+    fprintf(stdout, "starting %ld pingpongs\n", pingpongs);
+  }
+
+  for (uint64 i = 0; i < pingpongs; i++) {
+    if (pid > 0) {
+      // parent writes ping, reads pong
+      write(ping[1], &b, sizeof(b));
+      (void)read(pong[0], &buf, sizeof(buf));
+    } else if (pid == 0) {
+      // child reads ping, writes pong
+      (void)read(ping[0], &buf, sizeof(buf));
+      write(pong[1], &b, sizeof(b));
+    }
+  }
+
+  uint64 end = uptime();
+
+  if (pid == wait(0)) {
+    fprintf(stdout, "start: %ld, end: %ld, duration: %ld\n", start, end, (end - start));
+  }
+
+  exit(0);
+}

--- a/user/pingpongmsg.c
+++ b/user/pingpongmsg.c
@@ -1,0 +1,53 @@
+#include "kernel/types.h"
+#include "user.h"
+
+int main(void)
+{
+	int ping[2];
+  int pong[2];
+  (void)pipe(ping);
+  (void)pipe(pong);
+
+	int pid = fork();
+	if (pid == 0) {
+    // close and dup stdin to ping's readend
+    close(0);
+    (void)dup(ping[0]);
+
+    // close read and write end before catting
+    close(ping[0]);
+    close(ping[1]);
+
+    // write pong message and close before catting
+    char msg[] = "pong\n";
+    (void)write(pong[1], msg, sizeof(msg));
+    close(pong[0]);
+    close(pong[1]);
+
+    char *argv[] = { "cat", 0 };
+    exec("cat", argv);
+	} else if (pid > 0) {
+    // write ping message needs to happen before waiting or it'll deadlock
+    char msg[] = "ping\n";
+    (void)write(ping[1], msg, sizeof(msg));
+    close(ping[0]);
+    close(ping[1]);
+
+    // wait for child
+    wait(0);
+
+    // redirect pong to cat
+    close(0);
+    (void)dup(pong[0]);
+
+    // close fds before catting
+    close(pong[0]);
+    close(pong[1]);
+
+    // cat pong message
+    char *argv[] = { "cat", 0 };
+    exec("cat", argv);
+  }
+
+  exit(0);
+}


### PR DESCRIPTION
add `pingpong` and `pingpongmsg`

- `pingpong` pingpongs a single byte N times (input). Records start `uptime` and end `uptime` to get the duration
- `pingpongmsg` demonstrates redirection of messages by spoofing stdin

### Testing (qemu)
```
$ pingpong 1000
starting 1000 pingpongs
start: 26, end: 27, duration: 1
$ pingpong 100000
starting 100000 pingpongs
start: 88, end: 219, duration: 131
$ pingpongmsg
ping
pong
```