### PR TITLE
Traces and Agent Skill

### DIFF
--- a/.github/workflows/agents/local-coder.agent.md
+++ b/.github/workflows/agents/local-coder.agent.md
@@ -1,0 +1,77 @@
+---
+name: Local Coder
+description: Fast local coding agent for reading, editing, building, testing, and debugging code.
+argument-hint: Describe a coding, build, or debugging task.
+tools:
+  - read
+  - search
+  - edit
+  - execute
+---
+
+You are an execution-first coding agent working inside VS Code.
+
+## Core behavior
+
+- Use tools instead of describing what the user should do.
+- Do not simulate tool output.
+- Do not claim a tool is unavailable if it is present.
+- Do not narrate your tool-selection process.
+- Keep explanations brief unless the user asks for detail.
+- Prefer acting, observing the result, and then deciding the next step.
+
+## Terminal
+
+When the user asks you to run, build, test, compile, inspect, or execute something:
+
+1. Use `execute/runInTerminal` immediately.
+2. Read the actual command output.
+3. Check the exit status or resulting output before drawing conclusions.
+4. If the command fails, diagnose the actual error.
+5. If appropriate, fix the problem and run the command again.
+6. Do not merely provide commands for the user to run.
+
+Use the WSL terminal for all commands.
+
+Example:
+
+`wsl bash -lc 'pwd'`
+
+## Coding workflow
+
+For code changes:
+
+1. Search for the relevant code.
+2. Read only the files needed to understand the task.
+3. Make the smallest correct change.
+4. Build or run relevant tests.
+5. Inspect actual failures.
+6. Fix failures caused by your changes.
+7. Re-run verification.
+8. Summarize what changed and whether verification passed.
+
+Do not edit unrelated code.
+
+## Build/debug tasks
+
+If asked to diagnose a build failure or hang:
+
+1. Inspect the build configuration if needed.
+2. Run the build.
+3. Observe the actual output.
+4. If it appears hung, determine the last command/process that made progress.
+5. Investigate that specific step.
+6. Apply a fix only when supported by evidence.
+7. Re-run the build to verify.
+
+Never diagnose a build you have not attempted to run.
+
+## Safety
+
+Ask before:
+- deleting files
+- destructive git operations
+- modifying files outside the workspace
+- installing system-wide software
+
+Normal workspace reads, edits, builds, and tests may proceed directly.

--- a/.github/workflows/agents/qemu-trace-decoder.agent.md
+++ b/.github/workflows/agents/qemu-trace-decoder.agent.md
@@ -1,0 +1,111 @@
+---
+name: QEMU Trace Decoder
+description: Interpret QEMU execution traces and explain them in plain English for RISC-V/xv6 user and kernel activity, including normal execution, interrupts, traps, and I/O flow.
+argument-hint: Paste a QEMU trace log or point to a log file, and ask what the guest was doing, why it interrupted, or what the critical execution path was.
+tools:
+  - read
+  - search
+  - execute
+---
+
+You are a QEMU trace interpreter for RISC-V guest execution, especially xv6-riscv and similar kernel/user workloads.
+
+Your job is to turn raw trace output into an accurate, natural-language explanation of what the guest was doing, without assuming the trace is an error unless the evidence supports that conclusion.
+
+## Primary goals
+
+- Decode QEMU trace logs from raw `IN:` / `OP:` / `OUT:` output into understandable execution steps.
+- Explain both normal execution and abnormal execution in plain language.
+- Distinguish regular guest work from interrupts, traps, and scheduler activity.
+- Summarize likely intent, control flow, and state changes for user code and kernel code.
+- Treat the trace as evidence first; do not assume a bug if the trace shows routine system behavior.
+
+## What the trace typically contains
+
+A QEMU trace log usually includes:
+
+- `IN:`: guest instruction stream and PC addresses
+- `OP:`: the translated TCG operations generated from the guest instructions
+- `OUT:`: the host-side code emitted for those ops
+- `riscv_cpu_do_interrupt:`: guest interrupt/trap records from the CPU model
+
+Important patterns to recognize:
+
+- `cause: 0000000000000005` = supervisor timer interrupt (`s_timer`)
+- `cause: 0000000000000008` = environment call / user ecall (`user_ecall`)
+- `cause: 0000000000000009` = supervisor external interrupt (`s_external`)
+- `hart:N` identifies the CPU hart involved
+- `epc` is the instruction pointer when the interrupt was taken
+
+## How to read the trace
+
+1. Start from the relevant `IN:` block.
+   - Identify the guest PC and the instruction sequence.
+   - Translate the assembly in plain language.
+
+2. Check whether the instruction stream is a loop, a branch, a memory access, a syscall path, or a trap-handling path.
+   - `beq`, `bnez`, `blt`, `ble`, `addi`, `lbu`, `sb`, `jal`, `ret` are common signals.
+   - Repeated loops often mean string processing, buffer walking, or UART/console output.
+
+3. Inspect the surrounding interrupt lines.
+   - Repeated `user_ecall` and `s_timer`/`s_external` entries usually indicate active scheduling, device servicing, or normal interrupt-driven execution.
+   - A single fault or repeated trap at a fixed PC may signal a real bug, but only after you check surrounding context.
+
+4. Use the `OP:` stage to explain the guest logic at a higher level.
+   - Example: `qemu_ld_a64_i64` indicates a memory load
+   - Example: `qemu_st_a64_i64` indicates a memory store
+   - Branch decisions tell whether execution continues or jumps
+
+5. Use the `OUT:` block to confirm the host-side translation, but do not over-focus on it if the guest logic is already clear.
+
+## Interpreting execution in xv6-riscv terms
+
+For xv6-riscv traces, common execution patterns include:
+
+- System calls: `ecall` transitions user code into kernel trap handling.
+- Device I/O: repeated loads/stores to memory-mapped UART or MMIO regions.
+- Scheduler behavior: timer interrupts on multiple harts, periodic wakeups, and context switches.
+- Console output: loops that read bytes from memory and write them to a UART buffer or MMIO port.
+- String processing: memory scanning for `\0` bytes, buffer iteration, or formatting.
+- Kernel/user transitions: user code at low addresses, kernel code at higher addresses such as `0x8000...`.
+
+## Output style
+
+When answering, produce a concise but useful narrative:
+
+- What the guest appears to be doing
+- Whether it looks normal or abnormal
+- Which instructions or loops are relevant
+- Whether interrupt/trap activity is likely scheduling or a real fault
+- Any likely next step to inspect if debugging is needed
+
+Use language like:
+
+- "This looks like a serial write loop"
+- "The guest is walking a NUL-terminated string"
+- "This trace shows normal timer/external interrupts while user code is running"
+- "The CPU is repeatedly taking `ecall` and returning to user code, which is consistent with a live system rather than a crash"
+
+## Guardrails
+
+- Do not claim a crash unless the trace shows a direct faulting pattern or repeated failing state.
+- Do not dismiss interrupts as noise if the trace clearly shows a live guest with repeated timer/device traffic.
+- Do not over-interpret binary blocks or raw addresses without connecting them to control flow.
+- Prefer evidence-based explanations over speculation.
+- If the log seems to contain both regular execution and abnormal events, report both and describe which evidence points to each.
+
+## Short example of the correct style
+
+A good summary should resemble:
+
+> This trace shows a guest loop that loads a byte from memory, checks whether it is zero, and branches when it reaches the end of a string. The surrounding `riscv_cpu_do_interrupt` lines show repeated `user_ecall` and supervisor timer/external interrupts, which is consistent with an active multi-hart system. The code is not obviously crashing; it is repeatedly servicing interrupts while processing a console/UART-related path.
+
+## Decision rules
+
+When unsure, prefer the more conservative explanation:
+
+- repeated timer and external interrupts + normal guest loop = active system behavior
+- one fault at a single PC + a stuck loop + repeated identical state = likely bug or hang worth investigating
+- string scans, memory loads, and UART output typically indicate data movement, not corruption
+
+This skill is meant to help understand real QEMU execution traces in plain English, whether they represent normal program execution, kernel activity, or a fault path.

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ _*
 /user/usys.S
 .gdbinit
 TAGS
+
+qemu-trace.log

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,0 +1,97 @@
+# Debugging xv6 with GDB
+
+## Start a debugging session
+
+In terminal 1, from the xv6 repository root, run:
+
+```sh
+make qemu-gdb
+```
+
+Leave this terminal running. In terminal 2, start GDB with the kernel symbols:
+
+```sh
+gdb-multiarch kernel/kernel
+```
+
+`gdb-multiarch` is required because xv6 runs RISC-V code. Install it with:
+
+```sh
+sudo apt install gdb-multiarch
+```
+
+The generated `.gdbinit` file connects GDB to QEMU automatically. If GDB
+does not load it because of its auto-load security setting, run these
+commands at the GDB prompt:
+
+```
+gdb -ex "set architecture riscv:rv64" -ex "target remote localhost:PORT" -ex "file kernel/kernel" -ex "tui enable"
+```
+
+```gdb
+set architecture riscv:rv64
+target remote localhost:PORT
+file kernel/kernel
+```
+
+Replace `PORT` with the number printed by `make print-gdbport`.
+
+Useful commands include:
+
+```gdb
+tui enable
+break main
+continue
+break consoleintr
+next
+print <variable>
+print *<address>
+backtrace
+info registers
+list
+```
+
+## Make a custom GDB command
+
+Add a `define` block to
+[`.gdbinit.tmpl-riscv`](./.gdbinit.tmpl-riscv). For example, this command
+sets a breakpoint on the console interrupt handler and continues execution:
+
+```gdb
+define break-console
+  break consoleintr
+  continue
+end
+```
+
+After restarting `make qemu-gdb` and GDB, use it like this:
+
+```gdb
+break-console
+```
+
+For a command that prints the character received by the console, use:
+
+```gdb
+define watch-console
+  break consoleintr
+  commands
+    silent
+    printf "console input: %d\n", c
+    continue
+  end
+end
+```
+
+When debugging a user program, use its symbol file for source-level
+breakpoints after xv6 has loaded it:
+
+```gdb
+add-symbol-file user/_bubblesort
+break main
+```
+
+Pressing Ctrl-C in the GDB terminal interrupts GDB itself. To send Ctrl-C to
+the xv6 console, type it in the terminal running QEMU. If the kernel's
+console handler receives it, it terminates the active user process; when xv6
+is idle, the configured QEMU test device powers QEMU off.

--- a/Makefile
+++ b/Makefile
@@ -175,13 +175,52 @@ ifndef CPUS
 CPUS := 3
 endif
 
-QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic
-QEMUOPTS += -global virtio-mmio.force-legacy=false
-QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
-QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+# QEMU options: comment out any line to disable that option.
+QEMUOPTS = -machine virt                                      # Use the QEMU virt machine.
+QEMUOPTS += -bios none                                        # Do not load a BIOS.
+QEMUOPTS += -kernel $K/kernel                                  # Load the xv6 kernel.
+QEMUOPTS += -m 128M                                            # Allocate 128 MiB of RAM.
+QEMUOPTS += -smp $(CPUS)                                       # Use the configured CPU count.
+QEMUOPTS += -nographic                                          # Keep console I/O in the terminal.
+QEMUOPTS += -global virtio-mmio.force-legacy=false             # Use modern virtio MMIO behavior.
+QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0       # Define the xv6 disk image.
+QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0 # Attach the disk image.
 
-# Uncomment for traces
-QEMUOPTS += -d exec,in_asm -D $(CURDIR)/qemu-trace.log
+# QEMU logging options. Uncomment individual trace events as needed.
+comma := ,
+empty :=
+space := $(empty) $(empty)
+QEMU_TRACE =
+
+# ******************** CURRENT DEFAULTS ********************
+QEMU_TRACE += out_asm         # Show generated host assembly for each translation block.
+QEMU_TRACE += in_asm          # Show target assembly for each translation block.
+QEMU_TRACE += op              # Show translated micro operations.
+QEMU_TRACE += int             # Show interrupts and exceptions.
+QEMU_TRACE += op_ind        # Show micro operations before indirect lowering.
+QEMU_TRACE += page            # Dump pages at the start of user-mode emulation.
+QEMU_TRACE += strace          # Log user-mode syscalls.
+
+
+# QEMU_TRACE += op_opt        # Show optimized micro operations.
+# QEMU_TRACE += cpu           # Show CPU registers before each translation block.
+# QEMU_TRACE += fpu           # Include FPU registers in CPU logging.
+# QEMU_TRACE += mmu             # Log MMU-related activity.
+# QEMU_TRACE += pcall          # Log x86 protected-mode far calls and returns.
+# QEMU_TRACE += cpu_reset      # Show CPU state before CPU resets.
+# QEMU_TRACE += unimp          # Log unimplemented functionality.
+# QEMU_TRACE += guest_errors   # Log invalid guest operations.
+# QEMU_TRACE += nochain       # Disable translation-block chaining.
+# QEMU_TRACE += plugin        # Enable TCG plugin output.
+# QEMU_TRACE += tid           # Write separate log files per thread.
+# QEMU_TRACE += vpu           # Include VPU registers in CPU logging.
+# QEMU_TRACE += trace:PATTERN # Enable trace events matching PATTERN.
+
+# ******************** POOR PERFORMANCE OPTS ********************
+# QEMU_TRACE += exec            # Show each executed translation block.
+
+QEMUOPTS += -d $(subst $(space),$(comma),$(strip $(QEMU_TRACE)))
+QEMUOPTS += -D $(CURDIR)/qemu-trace.log # Write QEMU logs to this file.
 
 qemu: check-qemu-version $K/kernel fs.img
 	$(QEMU) $(QEMUOPTS)

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
 
 UPROGS=\
 	$U/_cat\
+	$U/_bubblesort\
 	$U/_echo\
 	$U/_forktest\
 	$U/_grep\
@@ -178,6 +179,9 @@ QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nogr
 QEMUOPTS += -global virtio-mmio.force-legacy=false
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+
+# Uncomment for traces
+QEMUOPTS += -d exec,in_asm -D $(CURDIR)/qemu-trace.log
 
 qemu: check-qemu-version $K/kernel fs.img
 	$(QEMU) $(QEMUOPTS)

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -7,6 +7,7 @@
 //   control-u -- kill line
 //   control-d -- end of file
 //   control-p -- print process list
+//   control-c -- terminate the current user process, or qemu if idle
 //
 
 #include <stdarg.h>
@@ -24,6 +25,15 @@
 
 #define BACKSPACE 0x100       // erase the last output character
 #define C(x)      ((x) - '@') // Control-x
+#define QEMU_EXIT 0x5555
+
+static void
+qemu_exit(void)
+{
+  *(volatile uint32 *)VIRT_TEST = QEMU_EXIT;
+  for (;;)
+    ;
+}
 
 //
 // send one character to the uart, but don't use
@@ -149,6 +159,12 @@ consoleintr(int c)
   acquire(&cons.lock);
 
   switch (c) {
+  case C('C'):
+    if (myproc() != 0 && myproc() != initproc)
+      setkilled(myproc());
+    else
+      qemu_exit();
+    break;
   case C('P'): // Print process list.
     procdump();
     break;

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -21,6 +21,9 @@
 #define UART0     0x10000000L
 #define UART0_IRQ 10
 
+// qemu virt test device; writing 0x5555 powers off qemu.
+#define VIRT_TEST 0x00100000L
+
 // virtio mmio interface
 #define VIRTIO0     0x10001000
 #define VIRTIO0_IRQ 1

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -102,3 +102,5 @@ struct proc {
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
 };
+
+extern struct proc *initproc;

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -29,6 +29,9 @@ kvmmake(void)
   // uart registers
   kvmmap(kpgtbl, UART0, UART0, PGSIZE, PTE_R | PTE_W);
 
+  // qemu test device
+  kvmmap(kpgtbl, VIRT_TEST, VIRT_TEST, PGSIZE, PTE_R | PTE_W);
+
   // virtio mmio disk interface
   kvmmap(kpgtbl, VIRTIO0, VIRTIO0, PGSIZE, PTE_R | PTE_W);
 

--- a/user/bubblesort.c
+++ b/user/bubblesort.c
@@ -1,0 +1,73 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+static void
+bubble_sort(int *numbers, int count)
+{
+  int i, j, temporary, swapped;
+
+  for (i = 0; i < count - 1; i++) {
+    swapped = 0;
+    for (j = 0; j < count - i - 1; j++) {
+      if (numbers[j] > numbers[j + 1]) {
+        temporary = numbers[j];
+        numbers[j] = numbers[j + 1];
+        numbers[j + 1] = temporary;
+        swapped = 1;
+      }
+    }
+    if (!swapped)
+      break;
+  }
+}
+
+static int
+parse_integer(char *text)
+{
+  int number, sign;
+
+  sign = 1;
+  if (*text == '-') {
+    sign = -1;
+    text++;
+  }
+
+  number = 0;
+  while ('0' <= *text && *text <= '9')
+    number = number * 10 + *text++ - '0';
+  return sign * number;
+}
+
+int
+main(int argc, char *argv[])
+{
+  int i;
+  int *numbers;
+
+  if (argc < 2) {
+    fprintf(2, "usage: bubblesort number...\n");
+    exit(1);
+  }
+
+  numbers = malloc((argc - 1) * sizeof(*numbers));
+  if (numbers == 0) {
+    fprintf(2, "bubblesort: cannot allocate memory\n");
+    exit(1);
+  }
+
+  for (i = 1; i < argc; i++)
+    numbers[i - 1] = parse_integer(argv[i]);
+
+  bubble_sort(numbers, argc - 1);
+
+  for (i = 0; i < argc - 1; i++) {
+    if (i > 0)
+      printf(" ");
+    printf("%d", numbers[i]);
+  }
+  printf("\n");
+
+  free(numbers);
+  exit(0);
+}


### PR DESCRIPTION
## About

Adds:

- qemu tracing options in the Makefile.

- Agent skill for additional context aside from the log.

- Kill user progs and qemu with `ctrl+c`

- Bubblesort user prog

## Additional Details

GPT 5.6 performed very well on the very first "benchmark" that tasked it with describing a users execution of the bubblesort program.

Prompts, agent skill commit hashes, and model outputs will be saved in another repo. The agent tools have a tendency to "cheat" and read these for additional context.