### PR TITLE
test-xv6.py: retry the log crash test often enough to be reliable

### DIFF
--- a/test-xv6.py
+++ b/test-xv6.py
@@ -159,7 +159,7 @@ def recover_orphan():
 
 def test_log():
     print("Test recovery of log")
-    for i in range(5):
+    for i in range(20):
         crash_log()
         ok = recover_log()
         if ok:


### PR DESCRIPTION
`./test-xv6.py crash` fails on CI a few percent of the time despite no kernel
changes. The most recent instance is the push build for #536 (my earlier PR),
which got me curious and prompted me to look into it.

`test_log()` crashes the xv6 kernel during `logstress` and asserts that the next
boot prints `recovering`. This is only the case if the SIGKILL-induced crash
occurs between the two `write_head()` calls in `commit()`, leaving the on-disk log
header non-zero. If the crash lands outside this window the log is already erased
and the next boot prints nothing.

Sampling over 48 attempts, a single attempt catches the log dirty about 40%
of the time. The suggested solution is to increase the number of attempts from 5
to 20. This reduces the chance that all attempts miss from about 8% to nearly 0%.

`./test-xv6.py log`, three consecutive runs: 1, 7 and 0 misses before the first
success. The middle run would have failed under the old limit.

Making the test truly deterministic would require checking the on-disk log header
in `fs.img` (the block `logstart` points to) and only demanding `recovering` when
that header is actually dirty. This is outside the scope of this change.
